### PR TITLE
Remove Jakarta Commons logging dependency.

### DIFF
--- a/auth-tokens/build.gradle
+++ b/auth-tokens/build.gradle
@@ -4,7 +4,6 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-guava:${jacksonVersion}"
     compile "com.google.guava:guava:${guavaVersion}"
-    compile "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     compile "org.slf4j:slf4j-api:${slf4jVersion}"
 
     processor "org.immutables:value:${immutablesVersion}"


### PR DESCRIPTION
I don't think it is being used anywhere and I don't believe it should be shipped with a library, but happy to be proved wrong; I ignored it in my project so not blocking.

@markelliot 
