### PR TITLE
debug log instead of warn log

### DIFF
--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
@@ -84,7 +84,7 @@ public class BasicAuthToBearerTokenFilter implements Filter {
             }
             return addBearerToken(request, authHeader);
         } else {
-            log.warn("Auth header is not basic auth.");
+            log.debug("Auth header is not basic auth.");
             return request;
         }
     }


### PR DESCRIPTION
git clients send a null auth header initially. Essentially spamming the logs every time we see a null auth header is bad
