### PR TITLE
Bump Gradle to 3.4.1 and make non-API dependencies implementation

### DIFF
--- a/auth-tokens-filter/build.gradle
+++ b/auth-tokens-filter/build.gradle
@@ -2,8 +2,8 @@ apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
     api "javax.servlet:javax.servlet-api:${servletApi}"
+    api project(':auth-tokens')
 
-    implementation project(':auth-tokens')
     implementation "javax.annotation:javax.annotation-api:${javaxAnnotationApi}"
     implementation "javax.ws.rs:javax.ws.rs-api:${jaxrsApi}"
     implementation "org.eclipse.jetty:jetty-security:${jettyVersion}"

--- a/auth-tokens-filter/build.gradle
+++ b/auth-tokens-filter/build.gradle
@@ -1,11 +1,11 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    api "javax.servlet:javax.servlet-api:${servletApi}"
     api project(':auth-tokens')
+    api "javax.ws.rs:javax.ws.rs-api:${jaxrsApi}"
+    api "javax.servlet:javax.servlet-api:${servletApi}"
 
     implementation "javax.annotation:javax.annotation-api:${javaxAnnotationApi}"
-    implementation "javax.ws.rs:javax.ws.rs-api:${jaxrsApi}"
     implementation "org.eclipse.jetty:jetty-security:${jettyVersion}"
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"

--- a/auth-tokens-filter/build.gradle
+++ b/auth-tokens-filter/build.gradle
@@ -1,13 +1,15 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile project(':auth-tokens')
-    compile "javax.servlet:javax.servlet-api:${servletApi}"
-    compile "javax.annotation:javax.annotation-api:${javaxAnnotationApi}"
-    compile "javax.ws.rs:javax.ws.rs-api:${jaxrsApi}"
-    compile "org.eclipse.jetty:jetty-security:${jettyVersion}"
-    compile "org.eclipse.jetty:jetty-server:${jettyVersion}"
-    compile "org.slf4j:slf4j-api:${slf4jVersion}"
+    api "javax.servlet:javax.servlet-api:${servletApi}"
+
+    implementation project(':auth-tokens')
+    implementation "javax.annotation:javax.annotation-api:${javaxAnnotationApi}"
+    implementation "javax.ws.rs:javax.ws.rs-api:${jaxrsApi}"
+    implementation "org.eclipse.jetty:jetty-security:${jettyVersion}"
+    implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "com.google.guava:guava:${guavaVersion}"
 
     testCompile "io.dropwizard:dropwizard-testing:${dropwizardVersion}"
     testCompile "junit:junit:$junitVersion"

--- a/auth-tokens/build.gradle
+++ b/auth-tokens/build.gradle
@@ -1,10 +1,10 @@
 apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
-    compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-guava:${jacksonVersion}"
-    compile "com.google.guava:guava:${guavaVersion}"
-    compile "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-guava:${jacksonVersion}"
+    implementation "com.google.guava:guava:${guavaVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
 
     processor "org.immutables:value:${immutablesVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'com.palantir.baseline-checkstyle'
     apply plugin: 'com.palantir.baseline-eclipse'
     apply plugin: 'com.palantir.baseline-findbugs'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 04 10:42:54 EDT 2016
+#Fri Mar 24 17:22:36 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip


### PR DESCRIPTION
This removes Guava from the compile classpath of dependent libraries, andkeeps it on Runtime, unless explicitly added.

This is not back compatible if a library depended on inheriting the compile dependency on these libraries.