### PR TITLE
[BREAK] Rename "tokens2" back to "tokens" for Maven group and Java package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Provides a filter to inject user identifier information into slf4j and Jetty log
 Gradle:
 ```
 dependencies {
-    compile "com.palantir.tokens2:auth-tokens:<version>"
-    compile "com.palantir.tokens2:auth-tokens-filter:<version>"
+    compile "com.palantir.tokens:auth-tokens:<version>"
+    compile "com.palantir.tokens:auth-tokens-filter:<version>"
 }
 ```
 

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth.http;
+package com.palantir.tokens.auth.http;
 
-import com.palantir.tokens2.auth.AuthHeader;
-import com.palantir.tokens2.auth.AuthTokensPreconditions;
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.AuthTokensPreconditions;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth.http;
+package com.palantir.tokens.auth.http;
 
-import com.palantir.tokens2.auth.AuthHeader;
-import com.palantir.tokens2.auth.UnverifiedJsonWebToken;
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.UnverifiedJsonWebToken;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilterTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilterTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth.http;
+package com.palantir.tokens.auth.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth.http;
+package com.palantir.tokens.auth.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyObject;

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/MockAppenderFactory.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/MockAppenderFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth.http;
+package com.palantir.tokens.auth.http;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/auth-tokens-filter/src/test/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/auth-tokens-filter/src/test/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,1 +1,1 @@
-com.palantir.tokens2.auth.http.MockAppenderFactory
+com.palantir.tokens.auth.http.MockAppenderFactory

--- a/auth-tokens-filter/versions.lock
+++ b/auth-tokens-filter/versions.lock
@@ -17,16 +17,16 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.palantir.tokens2:auth-tokens"
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.tokens2:auth-tokens"
+                "com.palantir.tokens:auth-tokens"
             ]
         },
-        "com.palantir.tokens2:auth-tokens": {
+        "com.palantir.tokens:auth-tokens": {
             "project": true
         },
         "javax.annotation:javax.annotation-api": {
@@ -73,7 +73,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
             "transitive": [
-                "com.palantir.tokens2:auth-tokens"
+                "com.palantir.tokens:auth-tokens"
             ]
         }
     },
@@ -95,16 +95,16 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.palantir.tokens2:auth-tokens"
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.tokens2:auth-tokens"
+                "com.palantir.tokens:auth-tokens"
             ]
         },
-        "com.palantir.tokens2:auth-tokens": {
+        "com.palantir.tokens:auth-tokens": {
             "project": true
         },
         "javax.annotation:javax.annotation-api": {
@@ -151,7 +151,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
             "transitive": [
-                "com.palantir.tokens2:auth-tokens"
+                "com.palantir.tokens:auth-tokens"
             ]
         }
     }

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import org.immutables.value.Value;
 

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthTokensPreconditions.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthTokensPreconditions.java
@@ -28,7 +28,7 @@
  * the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 /*
  * Derived from com.google.common.base.Preconditions

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerTokens.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerTokens.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/ImmutablesStyle.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/ImmutablesStyle.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/AuthHeaderTest.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/AuthHeaderTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokensTest.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokensTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.tokens2.auth;
+package com.palantir.tokens.auth;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
         propertiesFile file: project.rootProject.file('versions.props')
     }
 
-    group 'com.palantir.tokens2'
+    group 'com.palantir.tokens'
 
     repositories {
         jcenter()


### PR DESCRIPTION
lets just take the backcompat break in BearerTokens.fromPaths but keep
the package the same for the super-widely-used AuthHeader and
BearerToken classes