### PR TITLE
Narrow "Unable to process auth header" try/catch to actual parsing

### DIFF
--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
@@ -51,16 +51,16 @@ public class BearerTokenLoggingFilter implements ContainerRequestFilter {
             return;
         }
 
+        UnverifiedJsonWebToken jwt;
         try {
-            UnverifiedJsonWebToken jwt = UnverifiedJsonWebToken.of(
-                    AuthHeader.valueOf(rawAuthHeader).getBearerToken());
-
-            setUnverifiedContext(requestContext, USER_ID_KEY, jwt.getUnverifiedUserId());
-            jwt.getUnverifiedSessionId().ifPresent(s -> setUnverifiedContext(requestContext, SESSION_ID_KEY, s));
-            jwt.getUnverifiedTokenId().ifPresent(s -> setUnverifiedContext(requestContext, TOKEN_ID_KEY, s));
-        } catch (Throwable t) {
-            log.debug("Unable to process auth header.", t);
+            jwt = UnverifiedJsonWebToken.of(AuthHeader.valueOf(rawAuthHeader).getBearerToken());
+        } catch (IllegalArgumentException e) {
+            log.debug("Unable to process auth header.", e);
+            return;
         }
+        setUnverifiedContext(requestContext, USER_ID_KEY, jwt.getUnverifiedUserId());
+        jwt.getUnverifiedSessionId().ifPresent(s -> setUnverifiedContext(requestContext, SESSION_ID_KEY, s));
+        jwt.getUnverifiedTokenId().ifPresent(s -> setUnverifiedContext(requestContext, TOKEN_ID_KEY, s));
     }
 
     private void clearMdc() {


### PR DESCRIPTION
Current code can swallow important exceptions such as NoSuchMethodException

```
13131 DEBUG [2017-10-12T10:42:23.088Z] org.eclipse.jetty.servlet.ServletHandler: call filter io.dropwizard.servlets.ThreadNameFilter-122635ef
13132 DEBUG [2017-10-12T10:42:23.088Z] org.eclipse.jetty.servlet.ServletHandler: call filter io.dropwizard.jetty.BiDiGzipFilter-2db6d68d
13133 DEBUG [2017-10-12T10:42:23.088Z] org.eclipse.jetty.servlet.ServletHandler: call servlet io.dropwizard.jersey.setup.JerseyServletContainer-2213639b@48c92b86==io.dropwizard.jersey.setup.JerseyServletContainer,1,true
13134 DEBUG [2017-10-12T10:42:23.089Z] com.palantir.tokens.auth.http.BearerTokenLoggingFilter: Unable to process auth header. (throwable0_message: com.palantir.tokens.auth.UnverifiedJsonWebToken.getUnverifiedSessionId()Lcom/google/common/base/Optional;)
13135 java.lang.NoSuchMethodError: com.palantir.tokens.auth.UnverifiedJsonWebToken.getUnverifiedSessionId()Lcom/google/common/base/Optional;
13136 »»»»at com.palantir.tokens.auth.http.BearerTokenLoggingFilter.filter(BearerTokenLoggingFilter.java:55)
13137 »»»»at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:132)
13138 »»»»at org.glassfish.jersey.server.ContainerFilteringStage.apply(ContainerFilteringStage.java:68)
13139 »»»»at org.glassfish.jersey.process.internal.Stages.process(Stages.java:197)
13140 »»»»at org.glassfish.jersey.server.ServerRuntime$2.run(ServerRuntime.java:318)
13141 »»»»at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
13142 »»»»at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
13143 »»»»at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
13144 »»»»at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
13145 »»»»at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
13146 »»»»at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:317)
```