### PR TITLE
Much faster validation

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -18,7 +18,6 @@ package com.palantir.tokens.auth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.BitSet;
 import org.immutables.value.Value;
@@ -54,19 +53,17 @@ public abstract class BearerToken {
     @JsonValue
     public abstract String getToken();
 
-    /**
-     * isValidBearerToken validates that this is safe.
-     */
+    // We use a hand-written getBytes() implementation for performance reasons.
+    // Note that we don't need to worry about the character set (e.g., UTF-8) because
+    // the set of allowable characters are single bytes.
     @Value.Derived
     @SuppressWarnings("DesignForExtension")
     byte[] getTokenAsBytes() {
         String token = getToken();
         byte[] result = new byte[token.length()];
-
         for (int i = 0; i < result.length; i++) {
             result[i] = (byte) token.charAt(i);
         }
-
         return result;
     }
 

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -54,10 +54,20 @@ public abstract class BearerToken {
     @JsonValue
     public abstract String getToken();
 
+    /**
+     * isValidBearerToken validates that this is safe.
+     */
     @Value.Derived
     @SuppressWarnings("DesignForExtension")
     byte[] getTokenAsBytes() {
-        return getToken().getBytes(StandardCharsets.UTF_8);
+        String token = getToken();
+        byte[] result = new byte[token.length()];
+
+        for (int i = 0; i < result.length; i++) {
+            result[i] = (byte) token.charAt(i);
+        }
+
+        return result;
     }
 
     @JsonCreator
@@ -76,9 +86,12 @@ public abstract class BearerToken {
         int length = token.length();
         for (int i = 0; i < length; i++) {
             char character = token.charAt(i);
-            if ((isAtEnd && character != '=') || !allowedCharacters.get(character)) {
+            if (isAtEnd && character != '=') {
+                return false;
+            } else if (!allowedCharacters.get(character)) {
                 return false;
             }
+
             isAtEnd = isAtEnd || character == '=';
         }
         return true;

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -81,6 +81,7 @@ public abstract class BearerToken {
         return ImmutableBearerToken.of(token);
     }
 
+    // Optimized implementation of the regular expression VALIDATION_PATTERN_STRING
     private static boolean isValidBearerToken(String token) {
         boolean isAtEnd = false;
         int length = token.length();

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
+import javax.xml.bind.DatatypeConverter;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +111,7 @@ public abstract class UnverifiedJsonWebToken {
 
     private static JwtPayload extractPayload(String payload) {
         try {
-            return MAPPER.readValue(Base64.getDecoder().decode(payload), JwtPayload.class);
+            return MAPPER.readValue(DatatypeConverter.parseBase64Binary(payload), JwtPayload.class);
         } catch (IOException e) {
             throw new IllegalArgumentException("Invalid JWT: cannot parse payload", e);
         }
@@ -130,8 +130,10 @@ public abstract class UnverifiedJsonWebToken {
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
         long high = byteBuffer.getLong();
         long low = byteBuffer.getLong();
-        return new UUID(high, low).toString();
+
+        return UuidStringConverter.toString(new UUID(high, low));
     }
+
 
     private static class JwtPayload {
 

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -130,10 +130,8 @@ public abstract class UnverifiedJsonWebToken {
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
         long high = byteBuffer.getLong();
         long low = byteBuffer.getLong();
-
         return UuidStringConverter.toString(new UUID(high, low));
     }
-
 
     private static class JwtPayload {
 

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UuidStringConverter.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UuidStringConverter.java
@@ -21,6 +21,11 @@ import java.util.UUID;
 /**
  * Heavily based on Jackson's 'UUIDSerializer'. Changes made have been to change the format to comply
  * with Palantir style, and make the method return a string rather than writing into a JSON processor.
+ *
+ * That project is Apache 2.0 licensed, but the original source contains no license header on its own,
+ * so here we link to their license file.
+ *
+ * https://github.com/FasterXML/jackson-databind/blob/master/src/main/resources/META-INF/LICENSE
  */
 class UuidStringConverter {
     private final static char[] HEX_CHARS = "0123456789abcdef".toCharArray();
@@ -45,7 +50,6 @@ class UuidStringConverter {
         writeInt((int) lsb, ch, 28);
         return new String(ch);
     }
-
 
     private static void writeInt(int bits, char[] ch, int offset) {
         writeShort(bits >> 16, ch, offset);

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UuidStringConverter.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UuidStringConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth;
+
+import java.util.UUID;
+
+/**
+ * Heavily based on Jackson's 'UUIDSerializer'. Changes made have been to change the format to comply
+ * with Palantir style, and make the method return a string rather than writing into a JSON processor.
+ */
+class UuidStringConverter {
+    private final static char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+
+    private UuidStringConverter() {}
+
+    static String toString(UUID value) {
+        final char[] ch = new char[36];
+        final long msb = value.getMostSignificantBits();
+        writeInt((int) (msb >> 32), ch, 0);
+        ch[8] = '-';
+        int i = (int) msb;
+        writeShort(i >>> 16, ch, 9);
+        ch[13] = '-';
+        writeShort(i, ch, 14);
+        ch[18] = '-';
+
+        final long lsb = value.getLeastSignificantBits();
+        writeShort((int) (lsb >>> 48), ch, 19);
+        ch[23] = '-';
+        writeShort((int) (lsb >>> 32), ch, 24);
+        writeInt((int) lsb, ch, 28);
+        return new String(ch);
+    }
+
+
+    private static void writeInt(int bits, char[] ch, int offset) {
+        writeShort(bits >> 16, ch, offset);
+        writeShort(bits, ch, offset + 4);
+    }
+
+    private static void writeShort(int bits, char[] ch, int offset) {
+        ch[offset] = HEX_CHARS[(bits >> 12) & 0xF];
+        ch[offset + 1] = HEX_CHARS[(bits >> 8) & 0xF];
+        ch[offset + 2] = HEX_CHARS[(bits >> 4) & 0xF];
+        ch[offset + 3] = HEX_CHARS[bits & 0xF];
+    }
+}

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
@@ -43,7 +43,7 @@ public final class BearerTokenTests {
 
     @Test
     public void testFromString_specialCharacters() {
-        List<String> validTokens = Arrays.asList("-._~+/=", "abc=", "a=");
+        List<String> validTokens = Arrays.asList("-._~+/=", "a", "abc", "abc=", "a=", "a===");
         for (String validToken : validTokens) {
             BearerToken.valueOf(validToken);
         }

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UuidStringConverterTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UuidStringConverterTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+public class UuidStringConverterTests {
+
+    @Test
+    public void testToString() {
+        IntStream.range(0, 10_000)
+                .forEach(x -> {
+                    UUID uuid = UUID.randomUUID();
+                    assertThat(UuidStringConverter.toString(uuid)).isEqualTo(uuid.toString());
+                });
+    }
+}


### PR DESCRIPTION
To take a String header, convert it into a bearer token, and then turn it into
an unverified JWT takes 5400ns. Additionally the method itself requires the
bearer token, which adds another 3600ns - in total we spend 9us decoding
bearer tokens on each call. This is actually significant; if we want a service
to do 10k RPCs per core, they can expect roughly 9% of all CPU cycles to
be spent decoding bearer tokens.

This PR drops the overhead significantly; it hand codes the validation
of bearer tokens (which drops bearer token parsing to 450ns from 3600ns),
replaces UUID.toString (which is horrible) with a custom implementation
which saves about 450ns on each decode, and lastly replaces the base64
decoder with one from XML which runs 50ns faster (for free).

So, before: 5400ns, after: 1480ns