### PR TITLE
Performance improvements parsing UnverifiedJsonWebToken

### DIFF
--- a/auth-tokens-filter/versions.lock
+++ b/auth-tokens-filter/versions.lock
@@ -9,18 +9,10 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.palantir.tokens:auth-tokens"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
@@ -87,18 +79,10 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.palantir.tokens:auth-tokens"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -20,6 +20,7 @@ package com.palantir.tokens.auth;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -44,9 +45,10 @@ import org.slf4j.LoggerFactory;
 @ImmutablesStyle
 public abstract class UnverifiedJsonWebToken {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
+    private static final ObjectReader READER = new ObjectMapper()
             .registerModule(new Jdk8Module())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .readerFor(JwtPayload.class);
 
     private static final Logger log = LoggerFactory.getLogger(UnverifiedJsonWebToken.class);
 
@@ -75,7 +77,7 @@ public abstract class UnverifiedJsonWebToken {
      * before attempting to create an {@link UnverifiedJsonWebToken}.
      */
     public static Optional<UnverifiedJsonWebToken> tryParse(String rawAuthHeader) {
-        if (rawAuthHeader.chars().filter(x -> x == '.').count() == 2) {
+        if (countCharacter(rawAuthHeader, '.') == 2) {
             try {
                 return Optional.of(of(AuthHeader.valueOf(rawAuthHeader).getBearerToken()));
             } catch (Throwable t) {
@@ -83,6 +85,16 @@ public abstract class UnverifiedJsonWebToken {
             }
         }
         return Optional.empty();
+    }
+
+    private static int countCharacter(String input, char toCount) {
+        int count = 0;
+        for (int i = 0; i < input.length(); i++) {
+            if (input.charAt(i) == toCount) {
+                ++count;
+            }
+        }
+        return count;
     }
 
     /**
@@ -111,7 +123,7 @@ public abstract class UnverifiedJsonWebToken {
 
     private static JwtPayload extractPayload(String payload) {
         try {
-            return MAPPER.readValue(Base64.getDecoder().decode(payload), JwtPayload.class);
+            return READER.readValue(Base64.getDecoder().decode(payload));
         } catch (IOException e) {
             throw new IllegalArgumentException("Invalid JWT: cannot parse payload", e);
         }

--- a/auth-tokens/versions.lock
+++ b/auth-tokens/versions.lock
@@ -9,17 +9,10 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7"
         },
         "org.slf4j:slf4j-api": {
@@ -36,17 +29,10 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7"
         },
         "org.slf4j:slf4j-api": {

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile project(":auth-tokens")
+    compile 'com.google.guava:guava'
     compile 'org.openjdk.jmh:jmh-core'
     compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
     annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    compile project(":auth-tokens")
+    compile 'org.openjdk.jmh:jmh-core'
+    compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
+    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+}
+

--- a/benchmarks/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenBenchmarks.java
+++ b/benchmarks/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenBenchmarks.java
@@ -16,6 +16,7 @@
 
 package com.palantir.tokens.auth;
 
+import com.google.common.base.Strings;
 import java.util.Optional;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -30,7 +31,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 10, time = 5)
 @Measurement(iterations = 3, time = 3)
 public class UnverifiedJsonWebTokenBenchmarks {
-    private static final String NOT_JWT = repeat("NotJwt", 40);
+    private static final String NOT_JWT = Strings.repeat("NotJwt", 40);
     private static final String SESSION_TOKEN = "Bearer eyJhbGciOiJFUzI1NiJ9."
             + "eyJleHAiOjE0NTk1NTIzNDksInNpZCI6IlA4WmoxRDVJVGUyNlR0Z"
             + "UsrWXVEWXc9PSIsInN1YiI6Inc1UDJXUU1CUTA2cHlYSXdTbEIvL0E9PSJ9"
@@ -46,13 +47,5 @@ public class UnverifiedJsonWebTokenBenchmarks {
     @BenchmarkMode(Mode.Throughput)
     public final Optional<UnverifiedJsonWebToken> parseSessionToken() {
         return UnverifiedJsonWebToken.tryParse(SESSION_TOKEN);
-    }
-
-    private static String repeat(CharSequence seq, int count) {
-        StringBuilder buffer = new StringBuilder(seq.length() * count);
-        for (int i = 0; i < count; i++) {
-            buffer.append(seq);
-        }
-        return buffer.toString();
     }
 }

--- a/benchmarks/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenBenchmarks.java
+++ b/benchmarks/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenBenchmarks.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth;
+
+import java.util.Optional;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 10, time = 5)
+@Measurement(iterations = 3, time = 3)
+public class UnverifiedJsonWebTokenBenchmarks {
+    private static final String NOT_JWT = repeat("NotJwt", 40);
+    private static final String SESSION_TOKEN = "Bearer eyJhbGciOiJFUzI1NiJ9."
+            + "eyJleHAiOjE0NTk1NTIzNDksInNpZCI6IlA4WmoxRDVJVGUyNlR0Z"
+            + "UsrWXVEWXc9PSIsInN1YiI6Inc1UDJXUU1CUTA2cHlYSXdTbEIvL0E9PSJ9"
+            + ".XwPO_EEDVj6BBLScuf70_CH4jyI1ECmgVSoXLHpGlK-yIqm8MyUyFyNQTu8jh9kYheW-zBl64gmTnatkjjDH1A";
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public final Optional<UnverifiedJsonWebToken> parseNonJwt() {
+        return UnverifiedJsonWebToken.tryParse(NOT_JWT);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public final Optional<UnverifiedJsonWebToken> parseSessionToken() {
+        return UnverifiedJsonWebToken.tryParse(SESSION_TOKEN);
+    }
+
+    private static String repeat(CharSequence seq, int count) {
+        StringBuilder buffer = new StringBuilder(seq.length() * count);
+        for (int i = 0; i < count; i++) {
+            buffer.append(seq);
+        }
+        return buffer.toString();
+    }
+}

--- a/benchmarks/versions.lock
+++ b/benchmarks/versions.lock
@@ -1,0 +1,162 @@
+{
+    "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.tokens:auth-tokens"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "1.3.9",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.6.1-jre"
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "project": true
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "4.6",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.2",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.25",
+            "transitive": [
+                "com.palantir.tokens:auth-tokens"
+            ]
+        }
+    },
+    "runtime": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.tokens:auth-tokens"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "1.3.9",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.6.1-jre"
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "project": true
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "4.6",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.2",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.25",
+            "transitive": [
+                "com.palantir.tokens:auth-tokens"
+            ]
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 include 'auth-tokens'
 include 'auth-tokens-filter'
+include 'benchmarks'
 

--- a/versions.props
+++ b/versions.props
@@ -10,4 +10,5 @@ org.assertj:assertj-core = 3.6.1
 org.eclipse.jetty:* = 9.4.5.v20170502
 org.immutables:value = 2.5.3
 org.mockito:mockito-core = 1.10.19
+org.openjdk.jmh:* = 1.21
 org.slf4j:slf4j-api = 1.7.25

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,7 @@
 com.fasterxml.jackson.*:jackson-* = 2.6.7
 com.google.code.findbugs:jsr = 3.0.0
 com.google.code.findbugs:annotations = 3.0.0
+com.google.guava:guava = 23.6.1-jre
 io.dropwizard:dropwizard-testing = 0.9.2
 javax.annotation:javax.annotation-api = 1.2
 javax.servlet:javax.servlet-api = 3.1.0


### PR DESCRIPTION
Implemented JMH benchmarks for UnverifiedJsonWebToken.tryParse.

Results before this change:
```
UnverifiedJsonWebTokenBenchmarks.parseNonJwt        thrpt    3  8530177.987 ± 438717.090  ops/s
UnverifiedJsonWebTokenBenchmarks.parseSessionToken  thrpt    3   502692.902 ±  19562.944  ops/s
```

With this change:
```
UnverifiedJsonWebTokenBenchmarks.parseNonJwt        thrpt    3  14073771.303 ± 1743291.960  ops/s
UnverifiedJsonWebTokenBenchmarks.parseSessionToken  thrpt    3    662978.619 ±   66605.517  ops/s
```