### PR TITLE
Remove dependency on jackson-datatype-jdk8

### DIFF
--- a/auth-tokens/build.gradle
+++ b/auth-tokens/build.gradle
@@ -2,7 +2,6 @@ apply from: "${rootDir}/gradle/publish.gradle"
 
 dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
     compile "org.slf4j:slf4j-api"
 
     processor "org.immutables:value"

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -20,7 +20,6 @@ package com.palantir.tokens.auth;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -45,7 +44,6 @@ import org.slf4j.LoggerFactory;
 public abstract class UnverifiedJsonWebToken {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module())
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private static final Logger log = LoggerFactory.getLogger(UnverifiedJsonWebToken.class);
@@ -105,8 +103,8 @@ public abstract class UnverifiedJsonWebToken {
 
         return ImmutableUnverifiedJsonWebToken.of(
                 decodeUuidBytes(payload.sub),
-                payload.sid.map(UnverifiedJsonWebToken::decodeUuidBytes),
-                payload.jti.map(UnverifiedJsonWebToken::decodeUuidBytes));
+                Optional.ofNullable(payload.sid).map(UnverifiedJsonWebToken::decodeUuidBytes),
+                Optional.ofNullable(payload.jti).map(UnverifiedJsonWebToken::decodeUuidBytes));
     }
 
     private static JwtPayload extractPayload(String payload) {
@@ -139,21 +137,21 @@ public abstract class UnverifiedJsonWebToken {
         private byte[] sub;
 
         /**
-         * Indicates this token's session identifier (only for session tokens).
+         * Indicates this token's session identifier (only for session tokens, otherwise null).
          */
         @JsonProperty("sid")
-        private Optional<byte[]> sid = Optional.empty();
+        private byte[] sid;
 
         /**
-         * Indicates this token's expiry (only for session tokens).
+         * Indicates this token's expiry (only for session tokens, otherwise null).
          */
         @JsonProperty("exp")
-        private Optional<Long> exp = Optional.empty();
+        private Long exp;
 
         /**
-         * Indicates this token's identifier (only for API tokens).
+         * Indicates this token's identifier (only for API tokens, otherwise null).
          */
         @JsonProperty("jti")
-        private Optional<byte[]> jti = Optional.empty();
+        private byte[] jti;
     }
 }


### PR DESCRIPTION
Only used for an internal class, we can use Optional.ofNullable
ourselves.