### PR TITLE
Agressive optimization parsing UnverifiedJsonWebToken

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -77,10 +77,14 @@ public abstract class BearerToken {
         return ImmutableBearerToken.of(token);
     }
 
+    static boolean isValidBearerToken(String token) {
+        return isValidBearerToken(token, 0);
+    }
+
     // Optimized implementation of the regular expression VALIDATION_PATTERN_STRING
-    private static boolean isValidBearerToken(String token) {
+    static boolean isValidBearerToken(String token, int offset) {
         int length = token.length();
-        int cursor = 0;
+        int cursor = offset;
 
         for (; cursor < length; cursor++) {
             if (!allowedCharacters.get(token.charAt(cursor))) {
@@ -89,7 +93,7 @@ public abstract class BearerToken {
         }
 
         // Need at least one valid character
-        if (cursor == 0) {
+        if (cursor == offset) {
             return false;
         }
 

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/Tokens.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/Tokens.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth;
+
+import java.util.BitSet;
+
+/** Internal utility functions. */
+final class Tokens {
+
+    private static final BitSet allowedCharacters = new BitSet();
+
+    static {
+        allowedCharacters.set('A', 'Z' + 1);
+        allowedCharacters.set('a', 'z' + 1);
+        allowedCharacters.set('0', '9' + 1);
+        allowedCharacters.set('-');
+        allowedCharacters.set('.');
+        allowedCharacters.set('_');
+        allowedCharacters.set('~');
+        allowedCharacters.set('+');
+        allowedCharacters.set('/');
+    }
+
+    static boolean isValidBearerToken(String token) {
+        return isValidBearerToken(token, 0);
+    }
+
+    // Optimized implementation of the regular expression BearerToken.VALIDATION_PATTERN_STRING
+    static boolean isValidBearerToken(String token, int offset) {
+        int length = token.length();
+        int cursor = offset;
+
+        for (; cursor < length; cursor++) {
+            if (!allowedCharacters.get(token.charAt(cursor))) {
+                break;
+            }
+        }
+
+        // Need at least one valid character
+        if (cursor == offset) {
+            return false;
+        }
+
+        // Only trailing '=' is allowed after valid characters
+        for (; cursor < length; cursor++) {
+            if (token.charAt(cursor) != '=') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Callers are required to validate the input using {@link #isValidBearerToken(String)}
+     * prior to using this method.
+     *
+     * We use a hand-written getBytes() implementation for performance reasons.
+     * Note that we don't need to worry about the character set (e.g., UTF-8) because
+     * the set of allowable characters are single bytes.
+     */
+    static byte[] tokenValueAsBytes(String value, int offset, int length) {
+        byte[] result = new byte[length];
+        for (int i = 0; i < length; i++) {
+            result[i] = (byte) value.charAt(offset + i);
+        }
+        return result;
+    }
+
+    static byte[] tokenValueAsBytes(String value) {
+        return tokenValueAsBytes(value, 0, value.length());
+    }
+
+    private Tokens() {}
+}

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -20,6 +20,7 @@ package com.palantir.tokens.auth;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -44,9 +45,10 @@ import org.slf4j.LoggerFactory;
 @ImmutablesStyle
 public abstract class UnverifiedJsonWebToken {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
+    private static final ObjectReader READER = new ObjectMapper()
             .registerModule(new Jdk8Module())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .readerFor(JwtPayload.class);
 
     private static final Logger log = LoggerFactory.getLogger(UnverifiedJsonWebToken.class);
 
@@ -75,7 +77,7 @@ public abstract class UnverifiedJsonWebToken {
      * before attempting to create an {@link UnverifiedJsonWebToken}.
      */
     public static Optional<UnverifiedJsonWebToken> tryParse(String rawAuthHeader) {
-        if (rawAuthHeader.chars().filter(x -> x == '.').count() == 2) {
+        if (countCharacter(rawAuthHeader, '.') == 2) {
             try {
                 return Optional.of(of(AuthHeader.valueOf(rawAuthHeader).getBearerToken()));
             } catch (Throwable t) {
@@ -83,6 +85,16 @@ public abstract class UnverifiedJsonWebToken {
             }
         }
         return Optional.empty();
+    }
+
+    private static int countCharacter(String input, char toCount) {
+        int count = 0;
+        for (int i = 0; i < input.length(); i++) {
+            if (input.charAt(i) == toCount) {
+                ++count;
+            }
+        }
+        return count;
     }
 
     /**
@@ -111,7 +123,7 @@ public abstract class UnverifiedJsonWebToken {
 
     private static JwtPayload extractPayload(String payload) {
         try {
-            return MAPPER.readValue(Base64.getDecoder().decode(payload), JwtPayload.class);
+            return READER.readValue(Base64.getDecoder().decode(payload));
         } catch (IOException e) {
             throw new IllegalArgumentException("Invalid JWT: cannot parse payload", e);
         }

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
@@ -91,7 +91,7 @@ public final class UnverifiedJsonWebTokenTests {
             UnverifiedJsonWebToken.of(INVALID_BEARER_TOKEN);
             fail();
         } catch (RuntimeException e) {
-            assertEquals("Invalid JWT: expected 3 segments, found 1", e.getMessage());
+            assertEquals("Invalid JWT: cannot parse payload", e.getMessage());
         }
     }
 

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    compile project(":auth-tokens")
+    compile 'org.openjdk.jmh:jmh-core'
+    compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
+    annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
+}
+

--- a/benchmarks/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenBenchmarks.java
+++ b/benchmarks/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenBenchmarks.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth;
+
+import java.util.Optional;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 10, time = 5)
+@Measurement(iterations = 3, time = 3)
+public class UnverifiedJsonWebTokenBenchmarks {
+    private static final String NOT_JWT = repeat("NotJwt", 40);
+    private static final String SESSION_TOKEN = "Bearer eyJhbGciOiJFUzI1NiJ9."
+            + "eyJleHAiOjE0NTk1NTIzNDksInNpZCI6IlA4WmoxRDVJVGUyNlR0Z"
+            + "UsrWXVEWXc9PSIsInN1YiI6Inc1UDJXUU1CUTA2cHlYSXdTbEIvL0E9PSJ9"
+            + ".XwPO_EEDVj6BBLScuf70_CH4jyI1ECmgVSoXLHpGlK-yIqm8MyUyFyNQTu8jh9kYheW-zBl64gmTnatkjjDH1A";
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public final Optional<UnverifiedJsonWebToken> parseNonJwt() {
+        return UnverifiedJsonWebToken.tryParse(NOT_JWT);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public final Optional<UnverifiedJsonWebToken> parseSessionToken() {
+        return UnverifiedJsonWebToken.tryParse(SESSION_TOKEN);
+    }
+
+    private static String repeat(CharSequence seq, int count) {
+        StringBuilder buffer = new StringBuilder(seq.length() * count);
+        for (int i = 0; i < count; i++) {
+            buffer.append(seq);
+        }
+        return buffer.toString();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 include 'auth-tokens'
 include 'auth-tokens-filter'
+include 'benchmarks'
 

--- a/versions.props
+++ b/versions.props
@@ -10,4 +10,5 @@ org.assertj:assertj-core = 3.6.1
 org.eclipse.jetty:* = 9.4.5.v20170502
 org.immutables:value = 2.5.3
 org.mockito:mockito-core = 1.10.19
+org.openjdk.jmh:* = 1.21
 org.slf4j:slf4j-api = 1.7.25


### PR DESCRIPTION
This includes commits from #80

develop
```
UnverifiedJsonWebTokenBenchmarks.parseNonJwt        thrpt    3  8530177.987 ± 438717.090  ops/s
UnverifiedJsonWebTokenBenchmarks.parseSessionToken  thrpt    3   502692.902 ±  19562.944  ops/s
```

with this change
```
UnverifiedJsonWebTokenBenchmarks.parseNonJwt        thrpt    3  14136548.747 ± 1457545.553  ops/s
UnverifiedJsonWebTokenBenchmarks.parseSessionToken  thrpt    3   1035705.313 ±   48842.098  ops/s
```