### PR TITLE
Simpler AuthHeader.valueOf implementation

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
@@ -34,7 +34,8 @@ public abstract class AuthHeader {
      * Takes the string form: "Bearer [token]" and creates a new {@link AuthHeader}.
      */
     public static AuthHeader valueOf(String authHeader) {
-        BearerToken bearerToken = BearerToken.valueOf(authHeader.replaceFirst("^Bearer ", ""));
+        BearerToken bearerToken = BearerToken.valueOf(authHeader.startsWith("Bearer ")
+                ? authHeader.substring(7) : authHeader);
         return ImmutableAuthHeader.of(bearerToken);
     }
 


### PR DESCRIPTION
Use startsWith + substring rather than replaceFirst, resulting
in code that's easier to read.
Avoids unnecessaery regex compilation for such a trivial operation.