### PR TITLE
Cookie logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ dependencies {
 }
 ```
 
+In your server's initialize method:
+```java
+environment.jersey().register(BearerTokenLoggingFeature.class);
+```
+
+This is a jax-rs DynamicFeature which sets up either the `BearerTokenLoggingFilter` or the `BearerTokenCookieLoggingFilter`
+in front of each of your endpoints, depending on whether they have a `@HeaderParam("Authorization")` or a `@CookieParam(*) BearerToken`. If your endpoint has neither of these parameters then no filter will be added.
+
 ## Contributing
 
 Before working on the code, if you plan to contribute changes, please read the [CONTRIBUTING](CONTRIBUTING.md) document.

--- a/auth-tokens-filter/build.gradle
+++ b/auth-tokens-filter/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-security"
     compile "org.eclipse.jetty:jetty-server"
     compile "org.slf4j:slf4j-api"
+    implementation "com.palantir.safe-logging:preconditions"
 
     testCompile "io.dropwizard:dropwizard-testing"
     testCompile "junit:junit"

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenCookieLoggingFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenCookieLoggingFilter.java
@@ -28,11 +28,11 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 @Priority(Priorities.AUTHORIZATION)
-class CookieBearerTokenLoggingFilter implements ContainerRequestFilter {
+class BearerTokenCookieLoggingFilter implements ContainerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(BearerTokenLoggingFilter.class);
     private final String cookie;
 
-    public CookieBearerTokenLoggingFilter(String cookie) {
+    BearerTokenCookieLoggingFilter(String cookie) {
         this.cookie = cookie;
     }
 

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth.http;
+
+import static java.util.stream.Collectors.toList;
+
+import com.palantir.tokens.auth.BearerToken;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.List;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.HttpHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class BearerTokenLoggingFeature implements DynamicFeature {
+    private static final Logger log = LoggerFactory.getLogger(BearerTokenLoggingFeature.class);
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        Parameter[] parameters = resourceInfo.getResourceMethod().getParameters();
+
+        List<Parameter> authorizationHeaderParams = Arrays.stream(parameters)
+                .filter(param -> param.getAnnotation(HeaderParam.class) != null)
+                .filter(param -> param.getAnnotation(HeaderParam.class)
+                        .value()
+                        .equalsIgnoreCase(HttpHeaders.AUTHORIZATION))
+                .collect(toList());
+
+        if (authorizationHeaderParams.size() > 1) {
+            throw new IllegalStateException("Multiple parameters annotated with @HeaderParam('Authorization')");
+        }
+
+        if (authorizationHeaderParams.size() == 1) {
+            log.debug("Enabling BearerTokenLoggingFilter",
+                    resourceInfo.getResourceClass(),
+                    resourceInfo.getResourceMethod());
+            context.register(BearerTokenLoggingFilter.class);
+            return;
+        }
+
+        List<Parameter> cookieParams = Arrays.stream(parameters)
+                .filter(param -> param.getAnnotation(CookieParam.class) != null)
+                .filter(param -> param.getType().isAssignableFrom(BearerToken.class))
+                .collect(toList());
+
+        if (cookieParams.size() > 1) {
+            throw new IllegalStateException("Multiple BearerToken parameters annotated with @CookieParam");
+        }
+
+        if (cookieParams.size() == 1) {
+            String cookieName = cookieParams.get(0).getAnnotation(CookieParam.class).value();
+            log.debug("Enabling BearerTokenCookieLoggingFilter",
+                    resourceInfo.getResourceClass(),
+                    resourceInfo.getResourceMethod());
+            context.register(new BearerTokenCookieLoggingFilter(cookieName));
+            return;
+        }
+
+        log.debug(
+                "Not adding BearerTokenLoggingFilter or BearerTokenCookieLoggingFilter as no "
+                        + "@HeaderParam or @CookieParam annotated arguments were found",
+                resourceInfo.getResourceClass(),
+                resourceInfo.getResourceMethod());
+    }
+}

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth.http;
+
+import com.palantir.tokens.auth.UnverifiedJsonWebToken;
+import java.util.Optional;
+import javax.ws.rs.container.ContainerRequestContext;
+import org.slf4j.MDC;
+
+final class Utilities {
+
+    static void clearMdc() {
+        MDC.remove(Key.USER_ID.getMdcKey());
+        MDC.remove(Key.SESSION_ID.getMdcKey());
+        MDC.remove(Key.TOKEN_ID.getMdcKey());
+    }
+
+    /** Writes to both the MDC and ContainerRequestContext. */
+    static void recordUnverifiedJwt(
+            ContainerRequestContext requestContext,
+            Optional<UnverifiedJsonWebToken> parsedJwt) {
+        if (parsedJwt.isPresent()) {
+            UnverifiedJsonWebToken jwt = parsedJwt.get();
+            setUnverifiedContext(requestContext, Key.USER_ID, jwt.getUnverifiedUserId());
+            setUnverifiedContext(requestContext, Key.SESSION_ID, jwt.getUnverifiedSessionId());
+            setUnverifiedContext(requestContext, Key.TOKEN_ID, jwt.getUnverifiedTokenId());
+        }
+    }
+
+    private static void setUnverifiedContext(ContainerRequestContext requestContext, Key key, String value) {
+        MDC.put(key.getMdcKey(), value);
+        requestContext.setProperty(key.getContextKey(), value);
+    }
+
+    private static void setUnverifiedContext(ContainerRequestContext requestContext, Key key, Optional<String> value) {
+        if (value.isPresent()) {
+            setUnverifiedContext(requestContext, key, value.get());
+        }
+    }
+
+    enum Key {
+        USER_ID("userId"),
+        SESSION_ID("sessionId"),
+        TOKEN_ID("tokenId");
+
+        private final String mdc;
+        private final String context;
+
+        Key(String mdc) {
+            this.mdc = mdc;
+            this.context = BearerTokenLoggingFilter.getRequestPropertyKey(mdc);
+        }
+
+        public String getMdcKey() {
+            return mdc;
+        }
+
+        public String getContextKey() {
+            return context;
+        }
+    }
+
+    private Utilities() {}
+}

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeatureIntegTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeatureIntegTest.java
@@ -1,0 +1,119 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.tokens.auth.AuthHeader;
+import com.palantir.tokens.auth.BearerToken;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+public class BearerTokenLoggingFeatureIntegTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<Configuration> app = new DropwizardAppRule<>(Server.class);
+
+    private WebTarget target;
+
+    @Before
+    public void before() {
+        String endpointUri = "http://localhost:" + app.getLocalPort();
+        JerseyClientBuilder builder = new JerseyClientBuilder();
+        Client client = builder.build();
+        target = client.target(endpointUri);
+    }
+
+    @Test
+    public void mdc_values_should_be_populated_from_http_header() {
+        assertThat(target.path("/success").request()
+                .header("Authorization", TestConstants.AUTH_HEADER)
+                .get()
+                .getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void mdc_values_should_be_populated_when_cookie_is_a_bearertoken() {
+        assertThat(target.path("/cookies").request()
+                .cookie(new Cookie(
+                        "SOME_COOKIE",
+                        AuthHeader.valueOf(TestConstants.AUTH_HEADER).getBearerToken().toString()))
+                .get()
+                .getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void auth_header_passed_to_no_header_endpoint_is_not_picked_up() {
+        assertThat(target.path("/no-header").request()
+                .header("Authorization", TestConstants.AUTH_HEADER)
+                .get()
+                .getStatus()).isEqualTo(200);
+    }
+
+    public static final class Server extends Application<Configuration> {
+        @Override
+        public void run(Configuration configuration, Environment environment) throws Exception {
+            environment.jersey().register(new Resource());
+            environment.jersey().register(BearerTokenLoggingFeature.class);
+        }
+    }
+
+    @Path("/")
+    public static final class Resource {
+        @GET
+        @Path("success")
+        public boolean success(@HeaderParam(HttpHeaders.AUTHORIZATION) AuthHeader unused) {
+            assertThat(MDC.get("userId")).isEqualTo(TestConstants.USER_ID);
+            assertThat(MDC.get("sessionId")).isEqualTo(TestConstants.SESSION_ID);
+            assertThat(MDC.get("tokenId")).isEqualTo(TestConstants.TOKEN_ID);
+            return true;
+        }
+
+        @GET
+        @Path("cookies")
+        public boolean cookies(@CookieParam("SOME_COOKIE") BearerToken unused) {
+            assertThat(MDC.get("userId")).isEqualTo(TestConstants.USER_ID);
+            assertThat(MDC.get("sessionId")).isEqualTo(TestConstants.SESSION_ID);
+            assertThat(MDC.get("tokenId")).isEqualTo(TestConstants.TOKEN_ID);
+            return true;
+        }
+
+        @GET
+        @Path("no-header")
+        public boolean noHeader() {
+            assertThat(MDC.get("userId")).isNull();
+            assertThat(MDC.get("sessionId")).isNull();
+            assertThat(MDC.get("tokenId")).isNull();
+            return true;
+        }
+    }
+}

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeatureIntegTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeatureIntegTest.java
@@ -79,6 +79,16 @@ public class BearerTokenLoggingFeatureIntegTest {
                 .getStatus()).isEqualTo(200);
     }
 
+    @Test
+    public void non_auth_cookie_doesnt_get_logged() {
+        assertThat(target.path("/non-auth-cookie").request()
+                .cookie(new Cookie(
+                        "SOME_COOKIE",
+                        AuthHeader.valueOf(TestConstants.AUTH_HEADER).getBearerToken().toString()))
+                .get()
+                .getStatus()).isEqualTo(200);
+    }
+
     public static final class Server extends Application<Configuration> {
         @Override
         public void run(Configuration configuration, Environment environment) throws Exception {
@@ -89,6 +99,7 @@ public class BearerTokenLoggingFeatureIntegTest {
 
     @Path("/")
     public static final class Resource {
+
         @GET
         @Path("success")
         public boolean success(@HeaderParam(HttpHeaders.AUTHORIZATION) AuthHeader unused) {
@@ -104,6 +115,15 @@ public class BearerTokenLoggingFeatureIntegTest {
             assertThat(MDC.get("userId")).isEqualTo(TestConstants.USER_ID);
             assertThat(MDC.get("sessionId")).isEqualTo(TestConstants.SESSION_ID);
             assertThat(MDC.get("tokenId")).isEqualTo(TestConstants.TOKEN_ID);
+            return true;
+        }
+
+        @GET
+        @Path("non-auth-cookie")
+        public boolean nonAuthCookie(@CookieParam("NON_AUTH_COOKIE") Integer unused) {
+            assertThat(MDC.get("userId")).isNull();
+            assertThat(MDC.get("sessionId")).isNull();
+            assertThat(MDC.get("tokenId")).isNull();
             return true;
         }
 

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
@@ -22,12 +22,8 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
-import com.google.common.io.BaseEncoding;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
 import org.junit.Before;
@@ -43,19 +39,6 @@ public final class BearerTokenLoggingFilterTest {
     private static final String USER_ID_KEY = BearerTokenLoggingFilter.USER_ID_KEY;
     private static final String SESSION_ID_KEY = BearerTokenLoggingFilter.SESSION_ID_KEY;
     private static final String TOKEN_ID_KEY = BearerTokenLoggingFilter.TOKEN_ID_KEY;
-
-    private static final String USER_ID = UUID.randomUUID().toString();
-    private static final String SESSION_ID = UUID.randomUUID().toString();
-    private static final String TOKEN_ID = UUID.randomUUID().toString();
-    private static final String AUTH_HEADER = "Bearer "
-            + "unused."
-            + BaseEncoding.base64Url().omitPadding().encode(
-            ("{"
-                    + "\"sub\": \"" + encodeUuid(USER_ID) + "\","
-                    + "\"sid\": \"" + encodeUuid(SESSION_ID) + "\","
-                    + "\"jti\": \"" + encodeUuid(TOKEN_ID) + "\"}"
-            ).getBytes(StandardCharsets.UTF_8))
-            + ".unused";
 
     @Mock
     private ContainerRequestContext requestContext;
@@ -99,42 +82,42 @@ public final class BearerTokenLoggingFilterTest {
 
     @Test
     public void assertContextPropKeyPrefixIsStable() {
-        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(AUTH_HEADER);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(TestConstants.AUTH_HEADER);
         filter.filter(requestContext);
 
-        assertThat(MDC.get(USER_ID_KEY)).isEqualTo(USER_ID);
+        assertThat(MDC.get(USER_ID_KEY)).isEqualTo(TestConstants.USER_ID);
         assertThat(requestContext.getProperty("com.palantir.tokens.auth.userId"))
-                .isEqualTo(USER_ID);
+                .isEqualTo(TestConstants.USER_ID);
     }
 
     @Test
     public void userIdInformationIsSet() {
-        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(AUTH_HEADER);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(TestConstants.AUTH_HEADER);
         filter.filter(requestContext);
 
-        assertThat(MDC.get(USER_ID_KEY)).isEqualTo(USER_ID);
+        assertThat(MDC.get(USER_ID_KEY)).isEqualTo(TestConstants.USER_ID);
         assertThat(requestContext.getProperty(BearerTokenLoggingFilter.getRequestPropertyKey(USER_ID_KEY)))
-                .isEqualTo(USER_ID);
+                .isEqualTo(TestConstants.USER_ID);
     }
 
     @Test
     public void sessionIdInformationIsSet() {
-        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(AUTH_HEADER);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(TestConstants.AUTH_HEADER);
         filter.filter(requestContext);
 
-        assertThat(MDC.get(SESSION_ID_KEY)).isEqualTo(SESSION_ID);
+        assertThat(MDC.get(SESSION_ID_KEY)).isEqualTo(TestConstants.SESSION_ID);
         assertThat(requestContext.getProperty(BearerTokenLoggingFilter.getRequestPropertyKey(SESSION_ID_KEY)))
-                .isEqualTo(SESSION_ID);
+                .isEqualTo(TestConstants.SESSION_ID);
     }
 
     @Test
     public void tokenIdInformationIsSet() {
-        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(AUTH_HEADER);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(TestConstants.AUTH_HEADER);
         filter.filter(requestContext);
 
-        assertThat(MDC.get(TOKEN_ID_KEY)).isEqualTo(TOKEN_ID);
+        assertThat(MDC.get(TOKEN_ID_KEY)).isEqualTo(TestConstants.TOKEN_ID);
         assertThat(requestContext.getProperty(BearerTokenLoggingFilter.getRequestPropertyKey(TOKEN_ID_KEY)))
-                .isEqualTo(TOKEN_ID);
+                .isEqualTo(TestConstants.TOKEN_ID);
     }
 
     private void assertThatMdcIsCleared() {
@@ -147,13 +130,5 @@ public final class BearerTokenLoggingFilterTest {
         assertThat(MDC.get(USER_ID_KEY)).isNull();
         assertThat(MDC.get(SESSION_ID_KEY)).isNull();
         assertThat(MDC.get(TOKEN_ID_KEY)).isNull();
-    }
-
-    private static String encodeUuid(String uuidString) {
-        UUID uuid = UUID.fromString(uuidString);
-        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
-        bb.putLong(uuid.getMostSignificantBits());
-        bb.putLong(uuid.getLeastSignificantBits());
-        return BaseEncoding.base64().encode(bb.array());
     }
 }

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/MockAppenderFactory.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/MockAppenderFactory.java
@@ -22,9 +22,11 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.Layout;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.logging.AbstractAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
 
 /**
  * An {@link AbstractAppenderFactory} implementation that allows recovery of the appender
@@ -47,8 +49,12 @@ public final class MockAppenderFactory extends AbstractAppenderFactory {
     }
 
     @Override
-    public Appender<ILoggingEvent> build(LoggerContext context, String applicationName,
-            Layout<ILoggingEvent> layout) {
+    public Appender build(
+            LoggerContext context,
+            String applicationName,
+            LayoutFactory layoutFactory,
+            LevelFilterFactory levelFilterFactory,
+            AsyncAppenderFactory asyncAppenderFactory) {
         return MOCK_REQUEST_APPENDER;
     }
 }

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/TestConstants.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/TestConstants.java
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth.http;
+
+import com.google.common.io.BaseEncoding;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+final class TestConstants {
+
+    static final String USER_ID = UUID.randomUUID().toString();
+    static final String SESSION_ID = UUID.randomUUID().toString();
+    static final String TOKEN_ID = UUID.randomUUID().toString();
+    static final String AUTH_HEADER = "Bearer "
+            + "unused."
+            + BaseEncoding.base64Url().omitPadding().encode(
+            ("{"
+                    + "\"sub\": \"" + encodeUuid(USER_ID) + "\","
+                    + "\"sid\": \"" + encodeUuid(SESSION_ID) + "\","
+                    + "\"jti\": \"" + encodeUuid(TOKEN_ID) + "\"}"
+            ).getBytes(StandardCharsets.UTF_8))
+            + ".unused";
+
+    private static String encodeUuid(String uuidString) {
+        UUID uuid = UUID.fromString(uuidString);
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return BaseEncoding.base64().encode(bb.array());
+    }
+
+    private TestConstants() {}
+}

--- a/auth-tokens-filter/versions.lock
+++ b/auth-tokens-filter/versions.lock
@@ -1,19 +1,19 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]
@@ -34,29 +34,29 @@
             "locked": "2.0.1"
         },
         "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-server"
             ]
         },
         "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-http",
                 "org.eclipse.jetty:jetty-server"
             ]
         },
         "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.5.v20170502"
+            "locked": "9.4.6.v20170531"
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-security"
             ]
         },
         "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-http",
                 "org.eclipse.jetty:jetty-io"
@@ -71,19 +71,19 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]
@@ -104,29 +104,29 @@
             "locked": "2.0.1"
         },
         "org.eclipse.jetty:jetty-http": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-server"
             ]
         },
         "org.eclipse.jetty:jetty-io": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-http",
                 "org.eclipse.jetty:jetty-server"
             ]
         },
         "org.eclipse.jetty:jetty-security": {
-            "locked": "9.4.5.v20170502"
+            "locked": "9.4.6.v20170531"
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-security"
             ]
         },
         "org.eclipse.jetty:jetty-util": {
-            "locked": "9.4.5.v20170502",
+            "locked": "9.4.6.v20170531",
             "transitive": [
                 "org.eclipse.jetty:jetty-http",
                 "org.eclipse.jetty:jetty-io"

--- a/auth-tokens-filter/versions.lock
+++ b/auth-tokens-filter/versions.lock
@@ -18,6 +18,21 @@
                 "com.palantir.tokens:auth-tokens"
             ]
         },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.2",
+            "transitive": [
+                "com.palantir.safe-logging:safe-logging"
+            ]
+        },
+        "com.palantir.safe-logging:preconditions": {
+            "locked": "1.8.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "1.8.0",
+            "transitive": [
+                "com.palantir.safe-logging:preconditions"
+            ]
+        },
         "com.palantir.tokens:auth-tokens": {
             "project": true
         },

--- a/auth-tokens/versions.lock
+++ b/auth-tokens/versions.lock
@@ -1,19 +1,19 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.8.9"
         },
         "org.immutables:value": {
             "locked": "2.5.3"
@@ -24,19 +24,19 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7"
+            "locked": "2.8.9"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25"

--- a/benchmarks/versions.lock
+++ b/benchmarks/versions.lock
@@ -1,19 +1,19 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]
@@ -84,19 +84,19 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
+            "locked": "2.8.9",
             "transitive": [
                 "com.palantir.tokens:auth-tokens"
             ]

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:7.0.1'
+        classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:7.1.2'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:9.1.1'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.46.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.11.0'

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'org.inferred.processors'
 
     sourceCompatibility = 1.8

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,7 @@
 com.fasterxml.jackson.*:jackson-* = 2.8.9
 com.google.code.findbugs:annotations = 3.0.0
 com.google.guava:guava = 23.6.1-jre
+com.palantir.safe-logging:* = 1.8.0
 io.dropwizard:dropwizard-testing = 1.1.3
 javax.annotation:javax.annotation-api = 1.2
 javax.servlet:javax.servlet-api = 3.1.0

--- a/versions.props
+++ b/versions.props
@@ -1,13 +1,13 @@
-com.fasterxml.jackson.*:jackson-* = 2.6.7
+com.fasterxml.jackson.*:jackson-* = 2.8.9
 com.google.code.findbugs:annotations = 3.0.0
 com.google.guava:guava = 23.6.1-jre
-io.dropwizard:dropwizard-testing = 0.9.2
+io.dropwizard:dropwizard-testing = 1.1.3
 javax.annotation:javax.annotation-api = 1.2
 javax.servlet:javax.servlet-api = 3.1.0
 javax.ws.rs:javax.ws.rs-api = 2.0.1
 junit:junit = 4.12
 org.assertj:assertj-core = 3.6.1
-org.eclipse.jetty:* = 9.4.5.v20170502
+org.eclipse.jetty:* = 9.4.6.v20170531
 org.immutables:value = 2.5.3
 org.mockito:mockito-core = 1.10.19
 org.openjdk.jmh:* = 1.21


### PR DESCRIPTION
## Before this PR

Incoming requests that use cookies for auth don't get the MDC values or RequestContext populated for `userId`, `sessionId` or `tokenId`.

## After this PR

Users can register a single dynamic feature which will set up the right MDC values appropriately:

```diff
-resourceConfig.register(BearerTokenLoggingFilter.class)
+resourceConfig.register(BearerTokenLoggingFeature.class)
```

This is a jax-rs DynamicFeature, which checks each endpoint and wires up either header, cookie or no filter. This should handle even the trickiest hand-rolled jax-rs endpoints, including this one I found:

```
    @GET
    @Timed
    @Path("logout")
    public Response logout(
            @CookieParam(CookieManager.BROWSERID) BrowserId browserId,
            @CookieParam(CookieManager.TOKEN) BearerToken sessionToken,
            @Context HttpServletRequest request,
            @Context HttpServletResponse response) {
```