### PR TITLE
Fix BearerTokenLoggingFeature annotation detection and loading

### DIFF
--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
@@ -49,8 +49,7 @@ public class BasicAuthToBearerTokenFilter implements Filter {
     private static final Base64.Decoder BASE_64_ENCODING = Base64.getUrlDecoder();
 
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-    }
+    public void init(FilterConfig filterConfig) { }
 
     @Override
     public final void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenClearingFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenClearingFilter.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth.http;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+/**
+ * Clears any token related information for logging purposes. Makes sure that if no auth is specified on an endpoint
+ * none is persisted when using {@link BearerTokenLoggingFeature}
+ */
+@Priority(Priorities.AUTHORIZATION)
+public class BearerTokenClearingFilter implements ContainerRequestFilter {
+    @Override
+    public final void filter(ContainerRequestContext requestContext) {
+        Utilities.clearMdc();
+    }
+}

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
@@ -16,14 +16,16 @@
 
 package com.palantir.tokens.auth.http;
 
-import static java.util.stream.Collectors.toList;
-
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.tokens.auth.BearerToken;
+import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.container.DynamicFeature;
@@ -38,52 +40,77 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
 
     @Override
     public void configure(ResourceInfo resourceInfo, FeatureContext context) {
-        Parameter[] parameters = resourceInfo.getResourceMethod().getParameters();
+        List<Method> superInterfaceMethods = Stream.concat(
+                Stream.of(resourceInfo.getResourceMethod()),
+                Arrays.stream(resourceInfo.getResourceClass().getInterfaces())
+                        .flatMap(cls -> {
+                            try {
+                                return Stream.of(cls.getDeclaredMethod(
+                                        resourceInfo.getResourceMethod().getName(),
+                                        resourceInfo.getResourceMethod().getParameterTypes()));
+                            } catch (NoSuchMethodException e) {
+                                return Stream.empty();
+                            }
+                        })).collect(Collectors.toList());
 
-        List<Parameter> authorizationHeaderParams = Arrays.stream(parameters)
-                .filter(param -> param.getAnnotation(HeaderParam.class) != null)
-                .filter(param -> param.getAnnotation(HeaderParam.class)
-                        .value()
-                        .equalsIgnoreCase(HttpHeaders.AUTHORIZATION))
-                .collect(toList());
+        Optional<List<Parameter>> authorizationHeaderParams = superInterfaceMethods.stream()
+                .map(method -> Arrays.stream(method.getParameters())
+                        .filter(param -> param.getAnnotation(HeaderParam.class) != null)
+                        .filter(param -> param.getAnnotation(HeaderParam.class)
+                                .value()
+                                .equalsIgnoreCase(HttpHeaders.AUTHORIZATION))
+                        .collect(Collectors.toList()))
+                .filter(paramList -> !paramList.isEmpty())
+                .findFirst();
 
-        if (authorizationHeaderParams.size() > 1) {
-            throw new SafeIllegalStateException("Multiple parameters annotated with @HeaderParam('Authorization')",
+        if (authorizationHeaderParams.isPresent() && authorizationHeaderParams.get().size() > 1) {
+            throw new SafeIllegalStateException(
+                    "Multiple parameters annotated with @HeaderParam('Authorization')",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
                     SafeArg.of("method", resourceInfo.getResourceMethod()));
         }
 
-        if (authorizationHeaderParams.size() == 1) {
-            log.debug("Enabling BearerTokenLoggingFilter {} {}",
+        if (authorizationHeaderParams.isPresent() && authorizationHeaderParams.get().size() == 1) {
+            log.debug(
+                    "Enabling BearerTokenLoggingFilter {} {}",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
                     SafeArg.of("method", resourceInfo.getResourceMethod()));
             context.register(BearerTokenLoggingFilter.class);
             return;
         }
 
-        List<Parameter> cookieParams = Arrays.stream(parameters)
-                .filter(param -> param.getAnnotation(CookieParam.class) != null)
-                .filter(param -> param.getType().isAssignableFrom(BearerToken.class))
-                .collect(toList());
+        Optional<List<Parameter>> cookieParams = superInterfaceMethods.stream()
+                .map(method -> Arrays.stream(method.getParameters())
+                        .filter(param -> param.getAnnotation(CookieParam.class) != null)
+                        .filter(param -> param.getType().isAssignableFrom(BearerToken.class))
+                        .collect(Collectors.toList()))
+                .filter(paramList -> !paramList.isEmpty())
+                .findFirst();
 
-        if (cookieParams.size() > 1) {
-            throw new SafeIllegalStateException("Multiple BearerToken parameters annotated with @CookieParam",
+        if (cookieParams.isPresent() && cookieParams.get().size() > 1) {
+            throw new SafeIllegalStateException(
+                    "Multiple BearerToken parameters annotated with @CookieParam",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
                     SafeArg.of("method", resourceInfo.getResourceMethod()));
         }
 
-        if (cookieParams.size() == 1) {
-            String cookieName = cookieParams.get(0).getAnnotation(CookieParam.class).value();
-            log.debug("Enabling BearerTokenCookieLoggingFilter {} {}",
+        if (cookieParams.isPresent() && cookieParams.get().size() == 1) {
+            String cookieName = cookieParams.get().get(0).getAnnotation(CookieParam.class).value();
+            log.debug(
+                    "Enabling BearerTokenCookieLoggingFilter {} {}",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
                     SafeArg.of("method", resourceInfo.getResourceMethod()));
             context.register(new BearerTokenCookieLoggingFilter(cookieName));
             return;
         }
 
-        log.debug("Not adding BearerTokenLoggingFilter or BearerTokenCookieLoggingFilter as no "
+        log.debug(
+                "Setting filter to clear auth from logging information. "
+                        + "Not adding BearerTokenLoggingFilter or BearerTokenCookieLoggingFilter as no "
                         + "@HeaderParam or @CookieParam annotated arguments were found: {} {}",
                 SafeArg.of("class", resourceInfo.getResourceClass()),
                 SafeArg.of("method", resourceInfo.getResourceMethod()));
+
+        context.register(new BearerTokenClearingFilter());
     }
 }

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
@@ -37,6 +37,10 @@ import org.slf4j.MDC;
 public class BearerTokenLoggingFilter implements ContainerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(BearerTokenLoggingFilter.class);
 
+    public static final String USER_ID_KEY = Utilities.Key.USER_ID.getMdcKey();
+    public static final String SESSION_ID_KEY = Utilities.Key.SESSION_ID.getMdcKey();
+    public static final String TOKEN_ID_KEY = Utilities.Key.TOKEN_ID.getMdcKey();
+
     @Override
     public final void filter(ContainerRequestContext requestContext) {
         Utilities.clearMdc();
@@ -49,5 +53,15 @@ public class BearerTokenLoggingFilter implements ContainerRequestFilter {
 
         Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(rawAuthHeader);
         Utilities.recordUnverifiedJwt(requestContext, parsedJwt);
+    }
+
+    /**
+     * Construct mdc key for property.
+     *
+     * @deprecated MDC keys are considered private. Extract information directly from authorization in your application.
+     */
+    @Deprecated
+    public static String getRequestPropertyKey(String key) {
+        return "com.palantir.tokens.auth." + key;
     }
 }

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilter.java
@@ -37,10 +37,6 @@ import org.slf4j.MDC;
 public class BearerTokenLoggingFilter implements ContainerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(BearerTokenLoggingFilter.class);
 
-    public static final String USER_ID_KEY = Utilities.Key.USER_ID.getMdcKey();
-    public static final String SESSION_ID_KEY = Utilities.Key.SESSION_ID.getMdcKey();
-    public static final String TOKEN_ID_KEY = Utilities.Key.TOKEN_ID.getMdcKey();
-
     @Override
     public final void filter(ContainerRequestContext requestContext) {
         Utilities.clearMdc();
@@ -53,9 +49,5 @@ public class BearerTokenLoggingFilter implements ContainerRequestFilter {
 
         Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(rawAuthHeader);
         Utilities.recordUnverifiedJwt(requestContext, parsedJwt);
-    }
-
-    public static String getRequestPropertyKey(String key) {
-        return "com.palantir.tokens.auth." + key;
     }
 }

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
@@ -52,7 +52,7 @@ final class Utilities {
         }
     }
 
-    public static String getRequestPropertyKey(String key) {
+    static String getRequestPropertyKey(String key) {
         return "com.palantir.tokens.auth." + key;
     }
 

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
@@ -52,6 +52,10 @@ final class Utilities {
         }
     }
 
+    public static String getRequestPropertyKey(String key) {
+        return "com.palantir.tokens.auth." + key;
+    }
+
     enum Key {
         USER_ID("userId"),
         SESSION_ID("sessionId"),
@@ -62,7 +66,7 @@ final class Utilities {
 
         Key(String mdc) {
             this.mdc = mdc;
-            this.context = BearerTokenLoggingFilter.getRequestPropertyKey(mdc);
+            this.context = getRequestPropertyKey(mdc);
         }
 
         public String getMdcKey() {

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeatureIntegTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeatureIntegTest.java
@@ -117,7 +117,7 @@ public class BearerTokenLoggingFeatureIntegTest {
     }
 
     @Path("/inherited")
-    interface Resource {
+    public interface Resource {
         @GET
         @Path("success")
         boolean success(@HeaderParam(HttpHeaders.AUTHORIZATION) AuthHeader unused);

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
@@ -36,9 +36,9 @@ import org.slf4j.MDC;
 @RunWith(MockitoJUnitRunner.class)
 public final class BearerTokenLoggingFilterTest {
 
-    private static final String USER_ID_KEY = BearerTokenLoggingFilter.USER_ID_KEY;
-    private static final String SESSION_ID_KEY = BearerTokenLoggingFilter.SESSION_ID_KEY;
-    private static final String TOKEN_ID_KEY = BearerTokenLoggingFilter.TOKEN_ID_KEY;
+    private static final String USER_ID_KEY = Utilities.Key.USER_ID.getMdcKey();
+    private static final String SESSION_ID_KEY = Utilities.Key.SESSION_ID.getMdcKey();
+    private static final String TOKEN_ID_KEY = Utilities.Key.TOKEN_ID.getMdcKey();
 
     @Mock
     private ContainerRequestContext requestContext;
@@ -96,7 +96,7 @@ public final class BearerTokenLoggingFilterTest {
         filter.filter(requestContext);
 
         assertThat(MDC.get(USER_ID_KEY)).isEqualTo(TestConstants.USER_ID);
-        assertThat(requestContext.getProperty(BearerTokenLoggingFilter.getRequestPropertyKey(USER_ID_KEY)))
+        assertThat(requestContext.getProperty(Utilities.getRequestPropertyKey(USER_ID_KEY)))
                 .isEqualTo(TestConstants.USER_ID);
     }
 
@@ -106,7 +106,7 @@ public final class BearerTokenLoggingFilterTest {
         filter.filter(requestContext);
 
         assertThat(MDC.get(SESSION_ID_KEY)).isEqualTo(TestConstants.SESSION_ID);
-        assertThat(requestContext.getProperty(BearerTokenLoggingFilter.getRequestPropertyKey(SESSION_ID_KEY)))
+        assertThat(requestContext.getProperty(Utilities.getRequestPropertyKey(SESSION_ID_KEY)))
                 .isEqualTo(TestConstants.SESSION_ID);
     }
 
@@ -116,7 +116,7 @@ public final class BearerTokenLoggingFilterTest {
         filter.filter(requestContext);
 
         assertThat(MDC.get(TOKEN_ID_KEY)).isEqualTo(TestConstants.TOKEN_ID);
-        assertThat(requestContext.getProperty(BearerTokenLoggingFilter.getRequestPropertyKey(TOKEN_ID_KEY)))
+        assertThat(requestContext.getProperty(Utilities.getRequestPropertyKey(TOKEN_ID_KEY)))
                 .isEqualTo(TestConstants.TOKEN_ID);
     }
 


### PR DESCRIPTION
# Before this PR
You couldn't use BearerTokenLoggingFeature due to class loading cycles and annotation detection not working for interfaces
# After this PR
Both should work correctly