### PR TITLE
Fix logging in BearerTokenLoggingFeature

### DIFF
--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -67,14 +68,14 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
             throw new SafeIllegalStateException(
                     "Multiple parameters annotated with @HeaderParam('Authorization')",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
-                    SafeArg.of("method", resourceInfo.getResourceMethod()));
+                    SafeArg.of("method", Objects.toString(resourceInfo.getResourceMethod())));
         }
 
         if (authorizationHeaderParams.isPresent() && authorizationHeaderParams.get().size() == 1) {
             log.debug(
                     "Enabling BearerTokenLoggingFilter",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
-                    SafeArg.of("method", resourceInfo.getResourceMethod()));
+                    SafeArg.of("method", Objects.toString(resourceInfo.getResourceMethod())));
             context.register(BearerTokenLoggingFilter.class);
             return;
         }
@@ -91,7 +92,7 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
             throw new SafeIllegalStateException(
                     "Multiple BearerToken parameters annotated with @CookieParam",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
-                    SafeArg.of("method", resourceInfo.getResourceMethod()));
+                    SafeArg.of("method", Objects.toString(resourceInfo.getResourceMethod())));
         }
 
         if (cookieParams.isPresent() && cookieParams.get().size() == 1) {
@@ -99,7 +100,7 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
             log.debug(
                     "Enabling BearerTokenCookieLoggingFilter",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
-                    SafeArg.of("method", resourceInfo.getResourceMethod()));
+                    SafeArg.of("method", Objects.toString(resourceInfo.getResourceMethod())));
             context.register(new BearerTokenCookieLoggingFilter(cookieName));
             return;
         }
@@ -109,7 +110,7 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
                         + "Not adding BearerTokenLoggingFilter or BearerTokenCookieLoggingFilter as no "
                         + "@HeaderParam or @CookieParam annotated arguments were found.",
                 SafeArg.of("class", resourceInfo.getResourceClass()),
-                SafeArg.of("method", resourceInfo.getResourceMethod()));
+                SafeArg.of("method", Objects.toString(resourceInfo.getResourceMethod())));
 
         context.register(new BearerTokenClearingFilter());
     }

--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BearerTokenLoggingFeature.java
@@ -72,7 +72,7 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
         }
 
         if (authorizationHeaderParams.isPresent() && authorizationHeaderParams.get().size() == 1) {
-            log.debug(
+            log.info(
                     "Enabling BearerTokenLoggingFilter",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
                     SafeArg.of("method", Objects.toString(resourceInfo.getResourceMethod())));
@@ -97,7 +97,7 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
 
         if (cookieParams.isPresent() && cookieParams.get().size() == 1) {
             String cookieName = cookieParams.get().get(0).getAnnotation(CookieParam.class).value();
-            log.debug(
+            log.info(
                     "Enabling BearerTokenCookieLoggingFilter",
                     SafeArg.of("class", resourceInfo.getResourceClass()),
                     SafeArg.of("method", Objects.toString(resourceInfo.getResourceMethod())));
@@ -105,7 +105,7 @@ public final class BearerTokenLoggingFeature implements DynamicFeature {
             return;
         }
 
-        log.debug(
+        log.info(
                 "Setting filter to clear auth from logging information. "
                         + "Not adding BearerTokenLoggingFilter or BearerTokenCookieLoggingFilter as no "
                         + "@HeaderParam or @CookieParam annotated arguments were found.",

--- a/changelog/@unreleased/pr-146.v2.yml
+++ b/changelog/@unreleased/pr-146.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix logging in BearerTokenLoggingFeature.
+  links:
+  - https://github.com/palantir/auth-tokens/pull/146


### PR DESCRIPTION
## Before this PR

Logging `ResourceInfo.getResourceMethod()` directly, which throws an exception during serialization, concealing the error.

## After this PR
==COMMIT_MSG==
Fix logging in BearerTokenLoggingFeature.

`ResourceInfo.getResourceMethod()` is now turned into a string before being logged.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

