### PR TITLE
Add message arg to exceptions

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -16,16 +16,15 @@
 
 package com.palantir.tokens.auth;
 
+import static com.palantir.logsafe.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.security.MessageDigest;
 import java.util.BitSet;
 import org.immutables.value.Value;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Value class representing an authentication bearer token.
@@ -33,8 +32,6 @@ import org.slf4j.LoggerFactory;
 @Value.Immutable
 @ImmutablesStyle
 public abstract class BearerToken {
-
-    private static final Logger log = LoggerFactory.getLogger(BearerToken.class);
 
     private static final String VALIDATION_PATTERN_STRING = "^[A-Za-z0-9\\-\\._~\\+/]+=*$";
     private static final BitSet allowedCharacters = new BitSet();
@@ -50,6 +47,11 @@ public abstract class BearerToken {
         allowedCharacters.set('+');
         allowedCharacters.set('/');
     }
+
+    private static final String INVALID_TOKEN_NULL_MESSAGE = "BearerToken cannot be null";
+    private static final String INVALID_TOKEN_EMPTY_MESSAGE = "BearerToken cannot be empty";
+    private static final String INVALID_TOKEN_PATTERN_MESSAGE = "BearerToken must match pattern";
+
 
     @Value.Parameter
     @JsonValue
@@ -71,10 +73,18 @@ public abstract class BearerToken {
 
     @JsonCreator
     public static BearerToken valueOf(String token) {
-        Preconditions.checkArgument(token != null, "BearerToken cannot be null");
-        Preconditions.checkArgument(!token.isEmpty(), "BearerToken cannot be empty");
+        checkArgument(
+                token != null,
+                INVALID_TOKEN_NULL_MESSAGE,
+                SafeArg.of("message", INVALID_TOKEN_NULL_MESSAGE));
+        checkArgument(
+                !token.isEmpty(),
+                INVALID_TOKEN_EMPTY_MESSAGE,
+                SafeArg.of("message", INVALID_TOKEN_EMPTY_MESSAGE));
         if (!isValidBearerToken(token)) {
-            throw new SafeIllegalArgumentException("BearerToken must match pattern",
+            throw new SafeIllegalArgumentException(
+                    INVALID_TOKEN_PATTERN_MESSAGE,
+                    SafeArg.of("message", INVALID_TOKEN_PATTERN_MESSAGE),
                     SafeArg.of("validationPattern", VALIDATION_PATTERN_STRING));
         }
         return ImmutableBearerToken.of(token);

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
@@ -58,7 +58,9 @@ public final class BearerTokenTests {
             Assertions.assertThatLoggableExceptionThrownBy(() -> BearerToken.valueOf(invalidToken))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasLogMessage("BearerToken must match pattern")
-                    .hasExactlyArgs(SafeArg.of("validationPattern", "^[A-Za-z0-9\\-\\._~\\+/]+=*$"));
+                    .hasExactlyArgs(
+                            SafeArg.of("message", "BearerToken must match pattern"),
+                            SafeArg.of("validationPattern", "^[A-Za-z0-9\\-\\._~\\+/]+=*$"));
         }
     }
 

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
@@ -91,7 +91,9 @@ public final class UnverifiedJsonWebTokenTests {
         Assertions
                 .assertThatLoggableExceptionThrownBy(() -> UnverifiedJsonWebToken.of(INVALID_BEARER_TOKEN))
                 .hasLogMessage("Invalid JWT: expected 3 segments")
-                .hasExactlyArgs(SafeArg.of("segmentsCount", 1));
+                .hasExactlyArgs(
+                        SafeArg.of("message", "Invalid JWT: expected 3 segments"),
+                        SafeArg.of("segmentsCount", 1));
     }
 
     @Test
@@ -99,7 +101,7 @@ public final class UnverifiedJsonWebTokenTests {
         Assertions
                 .assertThatLoggableExceptionThrownBy(() -> UnverifiedJsonWebToken.of(INVALID_PAYLOAD_TOKEN))
                 .hasLogMessage("Invalid JWT: cannot parse payload")
-                .hasExactlyArgs();
+                .hasExactlyArgs(SafeArg.of("message", "Invalid JWT: cannot parse payload"));
     }
 
     private void assertValidApiToken(UnverifiedJsonWebToken token) {


### PR DESCRIPTION
## Before this PR
When an auth header is incorrect, the serialized error does not contain enough information for a client to know what was wrong. For example, providing a bearer token that does not match the required pattern results in the following response:
```
{
    "errorCode": "INVALID_ARGUMENT",
    "errorInstanceId": "5e876c95-ce13-4336-8bb0-4ac5716b1eea",
    "errorName": "Default:InvalidArgument",
    "parameters": {}
} 
```

For more context, see PDS-99495.

## After this PR
4xx errors include a `message` arg that provides information about why the request was invalid.

## Possible downsides?
I'm not convinced that duplicating the exception message as an arg is the correct solution, but providing this information to clients seems valuable. An alternative would be to include the exception message in the `SerializableError`, but it seems that we've [explicitly moved away](https://github.com/palantir/conjure-java-runtime-api/blob/2.3.0/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java#L96) from doing that.