### PR TITLE
Throw NotAuthorizedException for invalid tokens

### DIFF
--- a/auth-tokens/build.gradle
+++ b/auth-tokens/build.gradle
@@ -3,9 +3,10 @@ apply plugin: 'com.palantir.revapi'
 
 dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
+    compile "javax.ws.rs:javax.ws.rs-api"
     compile "org.slf4j:slf4j-api"
     implementation 'com.palantir.safe-logging:preconditions'
-    implementation 'javax.ws.rs:javax.ws.rs-api'
+
 
     annotationProcessor "org.immutables:value"
     compileOnly "org.immutables:value::annotations"

--- a/auth-tokens/build.gradle
+++ b/auth-tokens/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "org.slf4j:slf4j-api"
     implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'javax.ws.rs:javax.ws.rs-api'
 
     annotationProcessor "org.immutables:value"
     compileOnly "org.immutables:value::annotations"

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -23,6 +23,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.security.MessageDigest;
 import java.util.BitSet;
+import javax.ws.rs.NotAuthorizedException;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,8 +75,7 @@ public abstract class BearerToken {
         Preconditions.checkArgument(token != null, "BearerToken cannot be null");
         Preconditions.checkArgument(!token.isEmpty(), "BearerToken cannot be empty");
         if (!isValidBearerToken(token)) {
-            throw new SafeIllegalArgumentException("BearerToken must match pattern",
-                    SafeArg.of("validationPattern", VALIDATION_PATTERN_STRING));
+            throw new NotAuthorizedException("Bearer token must match pattern: " + VALIDATION_PATTERN_STRING);
         }
         return ImmutableBearerToken.of(token);
     }

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -18,9 +18,6 @@ package com.palantir.tokens.auth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.security.MessageDigest;
 import java.util.BitSet;
 import javax.ws.rs.NotAuthorizedException;
@@ -72,8 +69,12 @@ public abstract class BearerToken {
 
     @JsonCreator
     public static BearerToken valueOf(String token) {
-        Preconditions.checkArgument(token != null, "BearerToken cannot be null");
-        Preconditions.checkArgument(!token.isEmpty(), "BearerToken cannot be empty");
+        if (token == null) {
+            throw new NotAuthorizedException("Bearer token cannot be null");
+        }
+        if (token.isEmpty()) {
+            throw new NotAuthorizedException("Bearer token cannot be empty");
+        }
         if (!isValidBearerToken(token)) {
             throw new NotAuthorizedException("Bearer token must match pattern: " + VALIDATION_PATTERN_STRING);
         }

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/BearerTokenTests.java
@@ -22,12 +22,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.testing.Assertions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import javax.ws.rs.NotAuthorizedException;
 import org.junit.Test;
 
 /**
@@ -41,6 +40,7 @@ public final class BearerTokenTests {
     public void testConstructorUsage() {
         BearerToken bearerToken = BearerToken.valueOf(TOKEN_STRING);
         assertThat(bearerToken.getToken()).isEqualTo(TOKEN_STRING);
+        new NotAuthorizedException("asdf");
     }
 
     @Test
@@ -55,24 +55,23 @@ public final class BearerTokenTests {
     public void testFromString_invalidTokens() {
         List<String> invalidTokens = Arrays.asList(" space", "space ", "with space", "#", " ", "(", "=", "=a");
         for (String invalidToken : invalidTokens) {
-            Assertions.assertThatLoggableExceptionThrownBy(() -> BearerToken.valueOf(invalidToken))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasLogMessage("BearerToken must match pattern")
-                    .hasExactlyArgs(SafeArg.of("validationPattern", "^[A-Za-z0-9\\-\\._~\\+/]+=*$"));
+            assertThatThrownBy(() -> BearerToken.valueOf(invalidToken))
+                    .isInstanceOf(NotAuthorizedException.class)
+                    .hasMessageContaining("Bearer token must match pattern:");
         }
     }
 
     @Test
     public void testTokenCannotBeBlank() {
         assertThatThrownBy(() -> BearerToken.valueOf(""))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(NotAuthorizedException.class);
     }
 
     @Test
     @SuppressFBWarnings("NP_NULL_PARAM_DEREF_NONVIRTUAL")
     public void testTokenCannotBeNull() {
         assertThatThrownBy(() -> BearerToken.valueOf(null))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(NotAuthorizedException.class);
     }
 
     @Test

--- a/changelog/@unreleased/pr-227.v2.yml
+++ b/changelog/@unreleased/pr-227.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Throw `NotAuthorizedException` for malformed bearer tokens.
+  links:
+  - https://github.com/palantir/auth-tokens/pull/227


### PR DESCRIPTION
## Before this PR
Malformed token are thrown as IllegalArgumentException. Frameworks convert that to a 400 which is bad because:
1. The OAuth standard asks to respond with 401 for malformed tokens [(RFC)](https://tools.ietf.org/html/rfc6750#section-3.1).
2. Intermediary Conjure servers don't propagate 400s back to clients. They do however propagate 401s [(Github)](https://github.com/palantir/conjure-java/pull/615/). 

## After this PR
==COMMIT_MSG==
Throw `NotAuthorizedException` for malformed bearer tokens.
==COMMIT_MSG==

