### PR TITLE
Use SOURCE retention for immutables style annotations

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,7 @@
+acceptedBreaks:
+  "3.6.2":
+    com.palantir.tokens:auth-tokens:
+    - code: "java.class.visibilityReduced"
+      old: "@interface com.palantir.tokens.auth.ImmutablesStyle"
+      new: "@interface com.palantir.tokens.auth.ImmutablesStyle"
+      justification: "Hide internal annotation"

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/ImmutablesStyle.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/ImmutablesStyle.java
@@ -23,6 +23,6 @@ import java.lang.annotation.Target;
 import org.immutables.value.Value;
 
 @Target({ElementType.PACKAGE, ElementType.TYPE})
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, jdkOnly = true)
-public @interface ImmutablesStyle {}
+@interface ImmutablesStyle {}


### PR DESCRIPTION
See https://github.com/immutables/immutables/issues/291.

Example of a similar fix in https://github.com/palantir/conjure-java-runtime/pull/1897.

This eliminates compilation warnings for consumers that do not directly depend on immutables.