### PR TITLE
Revert hiding ImmutablesStyle

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/ImmutablesStyle.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/ImmutablesStyle.java
@@ -25,4 +25,4 @@ import org.immutables.value.Value;
 @Target({ElementType.PACKAGE, ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE, jdkOnly = true)
-@interface ImmutablesStyle {}
+public @interface ImmutablesStyle {}


### PR DESCRIPTION
Reverts the breaking change in https://github.com/palantir/auth-tokens/pull/474 because the downstream effects were more painful than anticipated.