### PR TITLE
Use Base64 URL decoder

### DIFF
--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/BasicAuthToBearerTokenFilter.java
@@ -47,7 +47,6 @@ public class BasicAuthToBearerTokenFilter implements Filter {
     private static final Logger log = LoggerFactory.getLogger(BasicAuthToBearerTokenFilter.class);
 
     private static final String BASIC_AUTH_STR = "Basic";
-    private static final Base64.Decoder BASE_64_ENCODING = Base64.getUrlDecoder();
 
     @Override
     public void init(FilterConfig _filterConfig) {}
@@ -115,7 +114,7 @@ public class BasicAuthToBearerTokenFilter implements Filter {
                 rawAuthHeader.substring(BASIC_AUTH_STR.length()).trim();
         String credentials;
         try {
-            credentials = new String(BASE_64_ENCODING.decode(base64Credentials), StandardCharsets.UTF_8);
+            credentials = new String(Base64.getUrlDecoder().decode(base64Credentials), StandardCharsets.UTF_8);
         } catch (IllegalArgumentException e) {
             throw new SafeIllegalArgumentException("Could not decode credentials from auth header", e);
         }

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -125,8 +125,8 @@ public abstract class UnverifiedJsonWebToken {
 
     private static JwtPayload extractPayload(String payload) {
         try {
-            return READER.readValue(Base64.getDecoder().decode(payload));
-        } catch (IOException e) {
+            return READER.readValue(Base64.getUrlDecoder().decode(payload));
+        } catch (IllegalArgumentException | IOException e) {
             throw new SafeIllegalArgumentException("Invalid JWT: cannot parse payload", e);
         }
     }

--- a/changelog/@unreleased/pr-487.v2.yml
+++ b/changelog/@unreleased/pr-487.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: |-
+    Use Base64 URL decoder
+
+    ## Before this PR
+    `UnverifiedJsonWebToken` now decodes token payloads using the correct Base64 URL decoder.
+  links:
+  - https://github.com/palantir/auth-tokens/pull/487

--- a/changelog/@unreleased/pr-487.v2.yml
+++ b/changelog/@unreleased/pr-487.v2.yml
@@ -1,9 +1,5 @@
 type: fix
 fix:
-  description: |-
-    Use Base64 URL decoder
-
-    ## Before this PR
-    `UnverifiedJsonWebToken` now decodes token payloads using the correct Base64 URL decoder.
+  description: '`UnverifiedJsonWebToken` now decodes token payloads using the correct Base64 URL decoder.'
   links:
   - https://github.com/palantir/auth-tokens/pull/487


### PR DESCRIPTION
## Before this PR
`UnverifiedJsonWebToken` decodes token payloads using the standard Base64 decoding.

However, JWT payloads are encoding using the Base64 URL encoding.

In practice, this hasn't an issue because all of our claims are either numbers or Base64 encoded UUIDs. None of these characters will result in `-` or `/` in the token payload.

## After this PR
`UnverifiedJsonWebToken` uses the correct Base64 URL decoder to decode token payloads.