### PR TITLE
Logging filters associate the JWT with the current request

### DIFF
--- a/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
+++ b/auth-tokens-filter/src/main/java/com/palantir/tokens/auth/http/Utilities.java
@@ -23,6 +23,8 @@ import org.slf4j.MDC;
 
 final class Utilities {
 
+    static final String JSON_WEB_TOKEN_KEY = getRequestPropertyKey("jwt");
+
     static void clearMdc() {
         MDC.remove(Key.USER_ID.getMdcKey());
         MDC.remove(Key.SESSION_ID.getMdcKey());
@@ -37,6 +39,7 @@ final class Utilities {
             setUnverifiedContext(requestContext, Key.USER_ID, jwt.getUnverifiedUserId());
             setUnverifiedContext(requestContext, Key.SESSION_ID, jwt.getUnverifiedSessionId());
             setUnverifiedContext(requestContext, Key.TOKEN_ID, jwt.getUnverifiedTokenId());
+            requestContext.setProperty(JSON_WEB_TOKEN_KEY, jwt);
         }
     }
 

--- a/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
+++ b/auth-tokens-filter/src/test/java/com/palantir/tokens/auth/http/BearerTokenLoggingFilterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import com.palantir.tokens.auth.UnverifiedJsonWebToken;
 import java.util.HashMap;
 import java.util.Map;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -90,6 +91,8 @@ final class BearerTokenLoggingFilterTest {
         assertThat(MDC.get(USER_ID_KEY)).isEqualTo(TestConstants.USER_ID);
         assertThat(requestContext.getProperty("com.palantir.tokens.auth.userId"))
                 .isEqualTo(TestConstants.USER_ID);
+        assertThat(requestContext.getProperty("com.palantir.tokens.auth.jwt"))
+                .isInstanceOf(UnverifiedJsonWebToken.class);
     }
 
     @Test
@@ -100,6 +103,9 @@ final class BearerTokenLoggingFilterTest {
         assertThat(MDC.get(USER_ID_KEY)).isEqualTo(TestConstants.USER_ID);
         assertThat(requestContext.getProperty(Utilities.getRequestPropertyKey(USER_ID_KEY)))
                 .isEqualTo(TestConstants.USER_ID);
+        assertThat(requestContext.getProperty(Utilities.JSON_WEB_TOKEN_KEY))
+                .isInstanceOfSatisfying(UnverifiedJsonWebToken.class, jwt -> assertThat(jwt.getUnverifiedUserId())
+                        .isEqualTo(TestConstants.USER_ID));
     }
 
     @Test
@@ -110,6 +116,9 @@ final class BearerTokenLoggingFilterTest {
         assertThat(MDC.get(SESSION_ID_KEY)).isEqualTo(TestConstants.SESSION_ID);
         assertThat(requestContext.getProperty(Utilities.getRequestPropertyKey(SESSION_ID_KEY)))
                 .isEqualTo(TestConstants.SESSION_ID);
+        assertThat(requestContext.getProperty(Utilities.JSON_WEB_TOKEN_KEY))
+                .isInstanceOfSatisfying(UnverifiedJsonWebToken.class, jwt -> assertThat(jwt.getUnverifiedSessionId())
+                        .hasValue(TestConstants.SESSION_ID));
     }
 
     @Test
@@ -120,6 +129,9 @@ final class BearerTokenLoggingFilterTest {
         assertThat(MDC.get(TOKEN_ID_KEY)).isEqualTo(TestConstants.TOKEN_ID);
         assertThat(requestContext.getProperty(Utilities.getRequestPropertyKey(TOKEN_ID_KEY)))
                 .isEqualTo(TestConstants.TOKEN_ID);
+        assertThat(requestContext.getProperty(Utilities.JSON_WEB_TOKEN_KEY))
+                .isInstanceOfSatisfying(UnverifiedJsonWebToken.class, jwt -> assertThat(jwt.getUnverifiedTokenId())
+                        .hasValue(TestConstants.TOKEN_ID));
     }
 
     private void assertThatMdcIsCleared() {

--- a/changelog/@unreleased/pr-543.v2.yml
+++ b/changelog/@unreleased/pr-543.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Logging filters associate the JWT with the current request
+  links:
+  - https://github.com/palantir/auth-tokens/pull/543


### PR DESCRIPTION
This allows us to extract the parsed value so we can add automatic
userId attribution to request logging, regardless of the
cookie-auth cookie name.

==COMMIT_MSG==
Logging filters associate the JWT with the current request
==COMMIT_MSG==

