### PR TITLE
Use case-insensitive matching for authentication scheme

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
@@ -36,8 +36,8 @@ public abstract class AuthHeader {
      * Takes the string form: "Bearer [token]" and creates a new {@link AuthHeader}.
      */
     public static AuthHeader valueOf(String authHeader) {
-        BearerToken bearerToken =
-                BearerToken.valueOf(authHeader.startsWith("Bearer ") ? authHeader.substring(7) : authHeader);
+        BearerToken bearerToken = BearerToken.valueOf(
+                authHeader.regionMatches(true, 0, "Bearer ", 0, 7) ? authHeader.substring(7) : authHeader);
         return ImmutableAuthHeader.of(bearerToken);
     }
 

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
@@ -36,8 +36,11 @@ public abstract class AuthHeader {
      * Takes the string form: "Bearer [token]" and creates a new {@link AuthHeader}.
      */
     public static AuthHeader valueOf(String authHeader) {
+        // See https://datatracker.ietf.org/doc/html/rfc7235#section-2.1
         BearerToken bearerToken = BearerToken.valueOf(
-                authHeader.regionMatches(true, 0, "Bearer ", 0, 7) ? authHeader.substring(7) : authHeader);
+                authHeader.regionMatches(/* ignoreCase */ true, 0, "Bearer ", 0, 7)
+                        ? authHeader.substring(7)
+                        : authHeader);
         return ImmutableAuthHeader.of(bearerToken);
     }
 

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/AuthHeaderTest.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/AuthHeaderTest.java
@@ -19,25 +19,29 @@ package com.palantir.tokens.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 final class AuthHeaderTest {
 
     @Test
-    void testSimple() {
-        BearerToken fromToken = BearerToken.valueOf("tokenTest");
-        AuthHeader authHeader = AuthHeader.of(fromToken);
-        assertThat(authHeader.getBearerToken()).isEqualTo(fromToken);
-        assertThat(authHeader.toString()).isEqualTo("Bearer tokenTest");
-        assertThat(AuthHeader.valueOf(authHeader.toString())).isEqualTo(authHeader);
+    void testFromToken() {
+        BearerToken bearerToken = BearerToken.valueOf("bearerToken");
+
+        AuthHeader authHeader = AuthHeader.of(bearerToken);
+
+        assertThat(authHeader.getBearerToken()).isEqualTo(bearerToken);
+        assertThat(authHeader.toString()).isEqualTo("Bearer bearerToken");
     }
 
-    @Test
-    void testToApiToken() {
-        assertThat(AuthHeader.valueOf("Bearer apiToken")).isEqualTo(AuthHeader.of(BearerToken.valueOf("apiToken")));
-    }
+    @ParameterizedTest
+    @ValueSource(strings = {"Bearer bearerToken", "bearer bearerToken", "BeArEr bearerToken", "bearerToken"})
+    void testFromString(String authHeaderString) {
+        BearerToken bearerToken = BearerToken.valueOf("bearerToken");
 
-    @Test
-    void testToApiToken_removeFirstBearer() {
-        assertThat(AuthHeader.valueOf("Bearer Bearer")).isEqualTo(AuthHeader.of(BearerToken.valueOf("Bearer")));
+        AuthHeader authHeader = AuthHeader.valueOf(authHeaderString);
+
+        assertThat(authHeader.getBearerToken()).isEqualTo(bearerToken);
+        assertThat(authHeader.toString()).isEqualTo("Bearer bearerToken");
     }
 }

--- a/changelog/@unreleased/pr-753.v2.yml
+++ b/changelog/@unreleased/pr-753.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: The `Authoziation` header authentication scheme is matching is case-insensitive.
+  links:
+  - https://github.com/palantir/auth-tokens/pull/753


### PR DESCRIPTION
## Before this PR
The `Authoziation` header authentication scheme is matching is case-sensitive.

But the authentication scheme is a case-insensitive value.

https://datatracker.ietf.org/doc/html/rfc7235#section-2.1

## After this PR
The `Authoziation` header authentication scheme is matching is case-insensitive.