### PR TITLE
Add support for org claim

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -56,6 +56,7 @@ public abstract class BearerToken {
     // Note that we don't need to worry about the character set (e.g., UTF-8) because
     // the set of allowable characters are single bytes.
     @Value.Derived
+    @DoNotLog
     @SuppressWarnings("DesignForExtension")
     byte[] getTokenAsBytes() {
         String token = getToken();

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -55,27 +55,35 @@ public abstract class UnverifiedJsonWebToken {
     private static final SafeLogger log = SafeLoggerFactory.get(UnverifiedJsonWebToken.class);
 
     /**
-     * Returns the unverified user id, i.e., the "sub" (subject) field of the JWT.
+     * Returns the unverified user id, i.e., the "sub" claim, of the JWT.
      */
     @Safe
     @Value.Parameter
     public abstract String getUnverifiedUserId();
 
     /**
-     * Returns the unverified session id for this token, i.e. the "sid" field of the JWT
-     * or absent if this token does not contain session information.
+     * Returns the unverified session id, i.e. the "sid" claim, of the JWT
+     * or absent if the JWT does not contain the "sid" claim.
      */
     @Safe
     @Value.Parameter
     public abstract Optional<String> getUnverifiedSessionId();
 
     /**
-     * Returns the unverified token id for this token, i.e. the "jti" field of the JWT
-     * or absent if this token does not use the "jti" field as a unique identifier.
+     * Returns the unverified token id, i.e. the "jti" claim, of the JWT
+     * or absent if the JWT does not contain the "jti" claim.
      */
     @Safe
     @Value.Parameter
     public abstract Optional<String> getUnverifiedTokenId();
+
+    /**
+     * Returns the unverified organization id, i.e. the "org" claim, of the JWT
+     * or absent if the JWT does not contain the "org" claim.
+     */
+    @Safe
+    @Value.Parameter
+    public abstract Optional<String> getUnverifiedOrganizationId();
 
     /**
      * Does a lower cost check on the structure of string provided
@@ -125,7 +133,8 @@ public abstract class UnverifiedJsonWebToken {
         return ImmutableUnverifiedJsonWebToken.of(
                 decodeUuidBytes(payload.sub),
                 Optional.ofNullable(payload.sid).map(UnverifiedJsonWebToken::decodeUuidBytes),
-                Optional.ofNullable(payload.jti).map(UnverifiedJsonWebToken::decodeUuidBytes));
+                Optional.ofNullable(payload.jti).map(UnverifiedJsonWebToken::decodeUuidBytes),
+                Optional.ofNullable(payload.org).map(UnverifiedJsonWebToken::decodeUuidBytes));
     }
 
     private static JwtPayload extractPayload(String payload) {
@@ -157,16 +166,13 @@ public abstract class UnverifiedJsonWebToken {
         @JsonProperty("sub")
         private byte[] sub;
 
-        /**
-         * Indicates this token's session identifier (only for session tokens, otherwise null).
-         */
         @JsonProperty("sid")
         private byte[] sid;
 
-        /**
-         * Indicates this token's identifier (only for API tokens, otherwise null).
-         */
         @JsonProperty("jti")
         private byte[] jti;
+
+        @JsonProperty("org")
+        private byte[] org;
     }
 }

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
@@ -26,49 +26,50 @@ import org.junit.jupiter.api.Test;
 
 final class UnverifiedJsonWebTokenTests {
 
-    private static final BearerToken SESSION_TOKEN = BearerToken.valueOf("header."
-            + "eyJleHAiOjE0NTk1NTIzNDksInNpZCI6IlA4WmoxRDVJVGUyNlR0ZUsrWXVEWXc9PSIs"
-            + "InN1YiI6Inc1UDJXUU1CUTA2cHlYSXdTbEIvL0E9PSJ9"
+    private static final BearerToken ALL_CLAIMS_TOKEN = BearerToken.valueOf("header."
+            + "eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0iLCJzaWQiOiJQOFpqMUQ1SVRlMjZUdGVLK1l1RFl3PT0iLCJqdGkiOiJwRm0w"
+            + "b1ZDSlQrQ0dWZFhmMmJLMy9RPT0iLCJvcmciOiJGQlMycTgvbFQvMnNBRktxZ09pUW13PT0iLCJleHAiOiAxNTc3ODY1NjAwfQ"
             + ".signature");
 
-    private static final BearerToken API_TOKEN = BearerToken.valueOf("header."
-            + "eyJleHAiOjE0NTk1NTIzNDksInN1YiI6Inc1UDJXUU1CUTA2cHlYSXdTbEIvL0E9PSIs"
-            + "Imp0aSI6InBGbTBvVkNKVCtDR1ZkWGYyYkszL1E9PSJ9."
-            + "signature");
+    private static final BearerToken REQUIRED_CLAIMS_TOKEN = BearerToken.valueOf(
+            "header." + "eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0iLCJleHAiOiAxNTc3ODY1NjAwfQ" + ".signature");
 
     private static final BearerToken INVALID_BEARER_TOKEN = BearerToken.valueOf("InvalidBearerToken");
 
     private static final BearerToken INVALID_ENCODING_TOKEN = BearerToken.valueOf("header."
-            + "eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0ifQo+."
-            + "signature");
+            + "eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0ifQo+"
+            + ".signature");
 
     private static final BearerToken INVALID_PAYLOAD_TOKEN = BearerToken.valueOf("header."
-            + "eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0iCg."
-            + "signature");
+            + "eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0iCg"
+            + ".signature");
 
     private static final String USERID = "c393f659-0301-434e-a9c9-72304a507ffc";
     private static final String SESSION_ID = "3fc663d4-3e48-4ded-ba4e-d78af98b8363";
     private static final String TOKEN_ID = "a459b4a1-5089-4fe0-8655-d5dfd9b2b7fd";
+    private static final String ORGANIZATION_ID = "1414b6ab-cfe5-4ffd-ac00-52aa80e8909b";
 
     @Test
-    void testAsJwt_validJwtFromSessionToken() {
-        UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(SESSION_TOKEN);
+    void testAsJwt_allClaims() {
+        UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(ALL_CLAIMS_TOKEN);
         assertThat(token.getUnverifiedUserId()).isEqualTo(USERID);
         assertThat(token.getUnverifiedSessionId()).contains(SESSION_ID);
-        assertThat(token.getUnverifiedTokenId()).isEmpty();
+        assertThat(token.getUnverifiedTokenId()).contains(TOKEN_ID);
+        assertThat(token.getUnverifiedOrganizationId()).contains(ORGANIZATION_ID);
 
-        Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(SESSION_TOKEN.getToken());
+        Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(ALL_CLAIMS_TOKEN.getToken());
         assertThat(tryToken).contains(token);
     }
 
     @Test
-    void testAsJwt_validJwtFromApiToken() {
-        UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(API_TOKEN);
+    void testAsJwt_requiredClaims() {
+        UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(REQUIRED_CLAIMS_TOKEN);
         assertThat(token.getUnverifiedUserId()).isEqualTo(USERID);
         assertThat(token.getUnverifiedSessionId()).isEmpty();
-        assertThat(token.getUnverifiedTokenId()).contains(TOKEN_ID);
+        assertThat(token.getUnverifiedTokenId()).isEmpty();
+        assertThat(token.getUnverifiedOrganizationId()).isEmpty();
 
-        Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(API_TOKEN.getToken());
+        Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(REQUIRED_CLAIMS_TOKEN.getToken());
         assertThat(tryToken).contains(token);
     }
 

--- a/changelog/@unreleased/pr-806.v2.yml
+++ b/changelog/@unreleased/pr-806.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: '`UnverifiedJsonWebToken` now supports the `org` claim.'
+  links:
+  - https://github.com/palantir/auth-tokens/pull/806


### PR DESCRIPTION
Add support for the `org` claim we are adding to our JWTs. This claim is also a Base64-encoded UUID.

For more context, see https://g.p.b/foundry/mp/pull/16056.

## Possible downsides?

This may break users of this library whose JWTs have an `org` claim that is not a Base64-encoded UUID. But we've never claimed that this library should be used for arbitrary JWTs - it's only intended to be used for Palantir JWTs.