### PR TITLE
Parse and expose "exp" claim

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -26,8 +26,6 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import org.immutables.value.Value;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -36,6 +34,7 @@ import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
+import org.immutables.value.Value;
 
 /**
  * Represents the parsed form of a JWT but does not verify the token signature.

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -26,12 +26,16 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import org.immutables.value.Value;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
-import org.immutables.value.Value;
 
 /**
  * Represents the parsed form of a JWT but does not verify the token signature.
@@ -86,6 +90,14 @@ public abstract class UnverifiedJsonWebToken {
     public abstract Optional<String> getUnverifiedOrganizationId();
 
     /**
+     * Returns the unverified expiration time, i.e. the "exp" claim, of the JWT
+     * or absent if the JWT does not contain the "exp" claim.
+     */
+    @Safe
+    @Value.Parameter
+    public abstract Optional<OffsetDateTime> getUnverifiedExpirationTime();
+
+    /**
      * Does a lower cost check on the structure of string provided
      * before attempting to create an {@link UnverifiedJsonWebToken}.
      */
@@ -134,7 +146,8 @@ public abstract class UnverifiedJsonWebToken {
                 decodeUuidBytes(payload.sub),
                 Optional.ofNullable(payload.sid).map(UnverifiedJsonWebToken::decodeUuidBytes),
                 Optional.ofNullable(payload.jti).map(UnverifiedJsonWebToken::decodeUuidBytes),
-                Optional.ofNullable(payload.org).map(UnverifiedJsonWebToken::decodeUuidBytes));
+                Optional.ofNullable(payload.org).map(UnverifiedJsonWebToken::decodeUuidBytes),
+                Optional.ofNullable(payload.exp).map(UnverifiedJsonWebToken::decodeEpochSeconds));
     }
 
     private static JwtPayload extractPayload(String payload) {
@@ -161,6 +174,16 @@ public abstract class UnverifiedJsonWebToken {
         return UuidStringConverter.toString(new UUID(high, low));
     }
 
+    /**
+     * Returns an OffsetDateTime representing the UTC date/time the given number of seconds after 1970-01-01T00:00:00Z.
+     * <p>
+     * This method ignores leap seconds, as does the "exp" claim
+     * (see <a href="https://www.rfc-editor.org/rfc/rfc7519#page-6">RFC 7519, page 6</a>).
+     */
+    private static OffsetDateTime decodeEpochSeconds(long epochSeconds) {
+        return OffsetDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC);
+    }
+
     private static final class JwtPayload {
 
         @JsonProperty("sub")
@@ -174,5 +197,8 @@ public abstract class UnverifiedJsonWebToken {
 
         @JsonProperty("org")
         private byte[] org;
+
+        @JsonProperty("exp")
+        private Long exp;
     }
 }

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.testing.Assertions;
 import java.io.IOException;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
@@ -51,8 +50,7 @@ final class UnverifiedJsonWebTokenTests {
     private static final String SESSION_ID = "3fc663d4-3e48-4ded-ba4e-d78af98b8363";
     private static final String TOKEN_ID = "a459b4a1-5089-4fe0-8655-d5dfd9b2b7fd";
     private static final String ORGANIZATION_ID = "1414b6ab-cfe5-4ffd-ac00-52aa80e8909b";
-    private static final OffsetDateTime EXPIRATION_TIME =
-            OffsetDateTime.ofInstant(Instant.ofEpochSecond(1577865600), ZoneOffset.UTC);
+    private static final OffsetDateTime EXPIRATION_TIME = OffsetDateTime.of(2020, 1, 1, 8, 0, 0, 0, ZoneOffset.UTC);
 
     @Test
     void testAsJwt_allClaims() {

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
@@ -21,6 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.testing.Assertions;
 import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -31,8 +34,8 @@ final class UnverifiedJsonWebTokenTests {
             + "b1ZDSlQrQ0dWZFhmMmJLMy9RPT0iLCJvcmciOiJGQlMycTgvbFQvMnNBRktxZ09pUW13PT0iLCJleHAiOiAxNTc3ODY1NjAwfQ"
             + ".signature");
 
-    private static final BearerToken REQUIRED_CLAIMS_TOKEN = BearerToken.valueOf(
-            "header." + "eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0iLCJleHAiOiAxNTc3ODY1NjAwfQ" + ".signature");
+    private static final BearerToken REQUIRED_CLAIMS_TOKEN =
+            BearerToken.valueOf("header." + "eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0ifQ" + ".signature");
 
     private static final BearerToken INVALID_BEARER_TOKEN = BearerToken.valueOf("InvalidBearerToken");
 
@@ -44,18 +47,21 @@ final class UnverifiedJsonWebTokenTests {
             + "eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0iCg"
             + ".signature");
 
-    private static final String USERID = "c393f659-0301-434e-a9c9-72304a507ffc";
+    private static final String USER_ID = "c393f659-0301-434e-a9c9-72304a507ffc";
     private static final String SESSION_ID = "3fc663d4-3e48-4ded-ba4e-d78af98b8363";
     private static final String TOKEN_ID = "a459b4a1-5089-4fe0-8655-d5dfd9b2b7fd";
     private static final String ORGANIZATION_ID = "1414b6ab-cfe5-4ffd-ac00-52aa80e8909b";
+    private static final OffsetDateTime EXPIRATION_TIME =
+            OffsetDateTime.ofInstant(Instant.ofEpochSecond(1577865600), ZoneOffset.UTC);
 
     @Test
     void testAsJwt_allClaims() {
         UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(ALL_CLAIMS_TOKEN);
-        assertThat(token.getUnverifiedUserId()).isEqualTo(USERID);
+        assertThat(token.getUnverifiedUserId()).isEqualTo(USER_ID);
         assertThat(token.getUnverifiedSessionId()).contains(SESSION_ID);
         assertThat(token.getUnverifiedTokenId()).contains(TOKEN_ID);
         assertThat(token.getUnverifiedOrganizationId()).contains(ORGANIZATION_ID);
+        assertThat(token.getUnverifiedExpirationTime()).contains(EXPIRATION_TIME);
 
         Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(ALL_CLAIMS_TOKEN.getToken());
         assertThat(tryToken).contains(token);
@@ -64,10 +70,11 @@ final class UnverifiedJsonWebTokenTests {
     @Test
     void testAsJwt_requiredClaims() {
         UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(REQUIRED_CLAIMS_TOKEN);
-        assertThat(token.getUnverifiedUserId()).isEqualTo(USERID);
+        assertThat(token.getUnverifiedUserId()).isEqualTo(USER_ID);
         assertThat(token.getUnverifiedSessionId()).isEmpty();
         assertThat(token.getUnverifiedTokenId()).isEmpty();
         assertThat(token.getUnverifiedOrganizationId()).isEmpty();
+        assertThat(token.getUnverifiedExpirationTime()).isEmpty();
 
         Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(REQUIRED_CLAIMS_TOKEN.getToken());
         assertThat(tryToken).contains(token);


### PR DESCRIPTION
## Before this PR

We do not support the "exp" claim defined in [RFC 7519 § 4.1.4](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4).

## After this PR

==COMMIT_MSG==
Parse and expose "exp" claim
==COMMIT_MSG==

## Possible downsides?

Some users might prefer the raw number value rather than the parsed NumericDate value.

## Benchmark

```
Before

Benchmark                                            Mode  Cnt         Score         Error  Units
UnverifiedJsonWebTokenBenchmarks.parseNonJwt        thrpt    3  28155737.632 ± 6352493.701  ops/s
UnverifiedJsonWebTokenBenchmarks.parseSessionToken  thrpt    3   1545347.909 ±  282668.819  ops/s

After

Benchmark                                            Mode  Cnt         Score         Error  Units
UnverifiedJsonWebTokenBenchmarks.parseNonJwt        thrpt    3  27780590.209 ± 4099857.530  ops/s
UnverifiedJsonWebTokenBenchmarks.parseSessionToken  thrpt    3   1460278.320 ±  108439.168  ops/s
```