### PR TITLE
Add support for svc claim

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,4 +1,9 @@
 acceptedBreaks:
+  "3.19.0":
+    com.palantir.tokens:auth-tokens:
+    - code: "java.method.abstractMethodAdded"
+      new: "method java.util.Optional<java.lang.String> com.palantir.tokens.auth.UnverifiedJsonWebToken::getUnverifiedService()"
+      justification: "UnverifiedJsonWebToken should not have external implementations"
   "3.6.2":
     com.palantir.tokens:auth-tokens:
     - code: "java.class.visibilityReduced"

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/AuthHeader.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
  * Represents a HTTP authentication header. This class wraps a string in the form of "Bearer [token]".
  */
 @DoNotLog
-@Value.Immutable
+@Value.Immutable(builder = false, copy = false)
 @ImmutablesStyle
 // NOTE: no @JsonSerialize/@JsonDeserialize because auth headers are for use in @HeaderParam
 // see: https://jersey.java.net/apidocs/latest/jersey/javax/ws/rs/HeaderParam.html

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -28,7 +28,7 @@ import org.immutables.value.Value;
 
 /** Value class representing an authentication bearer token. */
 @DoNotLog
-@Value.Immutable
+@Value.Immutable(builder = false, copy = false)
 @ImmutablesStyle
 public abstract class BearerToken {
 

--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/UnverifiedJsonWebToken.java
@@ -20,14 +20,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,7 +42,7 @@ import org.immutables.value.Value;
  * logging.
  */
 @Safe
-@Value.Immutable
+@Value.Immutable(builder = false, copy = false)
 @ImmutablesStyle
 public abstract class UnverifiedJsonWebToken {
 
@@ -84,6 +82,14 @@ public abstract class UnverifiedJsonWebToken {
     @Safe
     @Value.Parameter
     public abstract Optional<String> getUnverifiedOrganizationId();
+
+    /**
+     * Returns the unverified first-party service name, i.e. the "svc" claim, of the JWT
+     * or absent if the JWT does not contain the "svc" claim.
+     */
+    @Safe
+    @Value.Parameter
+    public abstract Optional<String> getUnverifiedService();
 
     /**
      * Does a lower cost check on the structure of string provided
@@ -131,10 +137,11 @@ public abstract class UnverifiedJsonWebToken {
         JwtPayload payload = extractPayload(segments[1]);
 
         return ImmutableUnverifiedJsonWebToken.of(
-                decodeUuidBytes(payload.sub),
-                Optional.ofNullable(payload.sid).map(UnverifiedJsonWebToken::decodeUuidBytes),
-                Optional.ofNullable(payload.jti).map(UnverifiedJsonWebToken::decodeUuidBytes),
-                Optional.ofNullable(payload.org).map(UnverifiedJsonWebToken::decodeUuidBytes));
+                UuidStringConverter.toString(payload.sub),
+                Optional.ofNullable(payload.sid).map(UuidStringConverter::toString),
+                Optional.ofNullable(payload.jti).map(UuidStringConverter::toString),
+                Optional.ofNullable(payload.org).map(UuidStringConverter::toString),
+                Optional.ofNullable(payload.svc));
     }
 
     private static JwtPayload extractPayload(String payload) {
@@ -145,34 +152,21 @@ public abstract class UnverifiedJsonWebToken {
         }
     }
 
-    /**
-     * Returns an encoded UUID from a length 16 byte array.
-     * <p>
-     * Palantir stores UUIDs in this format to optimize on shorter JWTs.
-     */
-    private static String decodeUuidBytes(byte[] bytes) {
-        Preconditions.checkArgument(
-                bytes.length == 16,
-                "Invalid JWT: cannot decode UUID, require 16 bytes",
-                SafeArg.of("bytesLength", bytes.length));
-        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
-        long high = byteBuffer.getLong();
-        long low = byteBuffer.getLong();
-        return UuidStringConverter.toString(new UUID(high, low));
-    }
-
     private static final class JwtPayload {
 
         @JsonProperty("sub")
-        private byte[] sub;
+        private UUID sub;
 
         @JsonProperty("sid")
-        private byte[] sid;
+        private UUID sid;
 
         @JsonProperty("jti")
-        private byte[] jti;
+        private UUID jti;
 
         @JsonProperty("org")
-        private byte[] org;
+        private UUID org;
+
+        @JsonProperty("svc")
+        private String svc;
     }
 }

--- a/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
+++ b/auth-tokens/src/test/java/com/palantir/tokens/auth/UnverifiedJsonWebTokenTests.java
@@ -26,67 +26,85 @@ import org.junit.jupiter.api.Test;
 
 final class UnverifiedJsonWebTokenTests {
 
-    private static final BearerToken ALL_CLAIMS_TOKEN = BearerToken.valueOf("header."
-            + "eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0iLCJzaWQiOiJQOFpqMUQ1SVRlMjZUdGVLK1l1RFl3PT0iLCJqdGkiOiJwRm0w"
-            + "b1ZDSlQrQ0dWZFhmMmJLMy9RPT0iLCJvcmciOiJGQlMycTgvbFQvMnNBRktxZ09pUW13PT0iLCJleHAiOiAxNTc3ODY1NjAwfQ"
-            + ".signature");
+    private static final BearerToken ALL_CLAIMS_TOKEN = BearerToken.valueOf("""
+        header.\
+        eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0iLCJzaWQiOiJQOFpqMUQ1SVRlMjZUdGVLK1l1RFl3PT0iLCJqdGkiOiJwRm0wb1ZDSlQ\
+        rQ0dWZFhmMmJLMy9RPT0iLCJvcmciOiJGQlMycTgvbFQvMnNBRktxZ09pUW13PT0iLCJzdmMiOiJzZXJ2aWNlIn0\
+        .signature\
+        """);
 
-    private static final BearerToken REQUIRED_CLAIMS_TOKEN = BearerToken.valueOf(
-            "header." + "eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0iLCJleHAiOiAxNTc3ODY1NjAwfQ" + ".signature");
+    private static final BearerToken REQUIRED_CLAIMS_TOKEN = BearerToken.valueOf("""
+        header.\
+        eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0ifQ\
+        .signature\
+        """);
 
-    private static final BearerToken INVALID_BEARER_TOKEN = BearerToken.valueOf("InvalidBearerToken");
+    private static final BearerToken INVALID_BEARER_TOKEN = BearerToken.valueOf("invalid");
 
-    private static final BearerToken INVALID_ENCODING_TOKEN = BearerToken.valueOf("header."
-            + "eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0ifQo+"
-            + ".signature");
+    private static final BearerToken INVALID_ENCODING_TOKEN = BearerToken.valueOf("""
+        header.\
+        eyJzdWIiOiJ3NVAyV1FNQlEwNnB5WEl3U2xCLy9BPT0ifQ+\
+        .signature\
+        """);
 
-    private static final BearerToken INVALID_PAYLOAD_TOKEN = BearerToken.valueOf("header."
-            + "eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0iCg"
-            + ".signature");
+    private static final BearerToken INVALID_PAYLOAD_TOKEN = BearerToken.valueOf("""
+        header.\
+        eyJzdWIiOiJrazlVMHB0ZVJ3K1FYYk55ZkZkcklBPT0iLCJqdGkiOiJ2MEtCNWdVTFJkT3dFWWh4Z1o3bERnPT0iCg\
+        .signature\
+        """);
 
     private static final String USERID = "c393f659-0301-434e-a9c9-72304a507ffc";
     private static final String SESSION_ID = "3fc663d4-3e48-4ded-ba4e-d78af98b8363";
     private static final String TOKEN_ID = "a459b4a1-5089-4fe0-8655-d5dfd9b2b7fd";
     private static final String ORGANIZATION_ID = "1414b6ab-cfe5-4ffd-ac00-52aa80e8909b";
+    private static final String SERVICE = "service";
 
     @Test
-    void testAsJwt_allClaims() {
+    void allClaims() {
         UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(ALL_CLAIMS_TOKEN);
         assertThat(token.getUnverifiedUserId()).isEqualTo(USERID);
         assertThat(token.getUnverifiedSessionId()).contains(SESSION_ID);
         assertThat(token.getUnverifiedTokenId()).contains(TOKEN_ID);
         assertThat(token.getUnverifiedOrganizationId()).contains(ORGANIZATION_ID);
+        assertThat(token.getUnverifiedService()).contains(SERVICE);
 
         Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(ALL_CLAIMS_TOKEN.getToken());
         assertThat(tryToken).contains(token);
     }
 
     @Test
-    void testAsJwt_requiredClaims() {
+    void requiredClaims() {
         UnverifiedJsonWebToken token = UnverifiedJsonWebToken.of(REQUIRED_CLAIMS_TOKEN);
         assertThat(token.getUnverifiedUserId()).isEqualTo(USERID);
         assertThat(token.getUnverifiedSessionId()).isEmpty();
         assertThat(token.getUnverifiedTokenId()).isEmpty();
         assertThat(token.getUnverifiedOrganizationId()).isEmpty();
+        assertThat(token.getUnverifiedService()).isEmpty();
 
         Optional<UnverifiedJsonWebToken> tryToken = UnverifiedJsonWebToken.tryParse(REQUIRED_CLAIMS_TOKEN.getToken());
         assertThat(tryToken).contains(token);
     }
 
     @Test
-    void invalidJwt_parseReturnsEmpty() {
+    void tryParse_invalidJwt() {
         Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(INVALID_BEARER_TOKEN.getToken());
         assertThat(parsedJwt).isNotPresent();
     }
 
     @Test
-    void invalidJwt_parseReturnsEmpty_validStructure() {
+    void tryParse_invalidEncoding() {
+        Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(INVALID_ENCODING_TOKEN.getToken());
+        assertThat(parsedJwt).isNotPresent();
+    }
+
+    @Test
+    void tryParse_invalidPayload() {
         Optional<UnverifiedJsonWebToken> parsedJwt = UnverifiedJsonWebToken.tryParse(INVALID_PAYLOAD_TOKEN.getToken());
         assertThat(parsedJwt).isNotPresent();
     }
 
     @Test
-    void invalidJwt_invalidNumberOfSegments() {
+    void of_invalidJwt() {
         Assertions.assertThatLoggableExceptionThrownBy(() -> UnverifiedJsonWebToken.of(INVALID_BEARER_TOKEN))
                 .hasLogMessage("Invalid JWT: expected 3 segments")
                 .hasExactlyArgs(SafeArg.of("segmentsCount", 1))
@@ -94,7 +112,7 @@ final class UnverifiedJsonWebTokenTests {
     }
 
     @Test
-    void invalidJwt_invalidEncodingToken() {
+    void of_invalidEncoding() {
         Assertions.assertThatLoggableExceptionThrownBy(() -> UnverifiedJsonWebToken.of(INVALID_ENCODING_TOKEN))
                 .hasLogMessage("Invalid JWT: cannot parse payload")
                 .hasNoArgs()
@@ -102,7 +120,7 @@ final class UnverifiedJsonWebTokenTests {
     }
 
     @Test
-    void invalidJwt_invalidPayloadToken() {
+    void of_invalidPayload() {
         Assertions.assertThatLoggableExceptionThrownBy(() -> UnverifiedJsonWebToken.of(INVALID_PAYLOAD_TOKEN))
                 .hasLogMessage("Invalid JWT: cannot parse payload")
                 .hasNoArgs()


### PR DESCRIPTION
Add support for the `svc` claim we are adding to our JWTs.

For more context, see https://g.p.b/foundry/mp/pull/24561.