### PR TITLE
Remove tokenBytes

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -21,10 +21,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.BitSet;
-import org.jspecify.annotations.Nullable;
 
 /** Value class representing an authentication bearer token. */
 @DoNotLog
@@ -48,8 +46,6 @@ public final class BearerToken {
 
     private final String token;
 
-    private volatile byte @Nullable [] tokenBytes;
-
     private BearerToken(String token) {
         checkValidBearerToken(token);
         this.token = token;
@@ -64,13 +60,6 @@ public final class BearerToken {
     @DoNotLog
     public String getToken() {
         return token;
-    }
-
-    private byte[] getTokenBytes() {
-        if (tokenBytes == null) {
-            tokenBytes = token.getBytes(StandardCharsets.US_ASCII);
-        }
-        return tokenBytes;
     }
 
     // Optimized validity check instead of using regular expressions
@@ -108,10 +97,40 @@ public final class BearerToken {
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof BearerToken bearerToken) {
-            return MessageDigest.isEqual(getTokenBytes(), bearerToken.getTokenBytes());
+        if (!(other instanceof BearerToken bearerToken)) {
+            return false;
         }
-        return false;
+
+        return isEqual(token, bearerToken.token);
+    }
+
+    /**
+     * Copied from {@link MessageDigest#isEqual(byte[], byte[])} and modified to compare {@link String} values using
+     * {@link String#charAt(int)}.
+     */
+    @SuppressWarnings("ReferenceEquality")
+    private static boolean isEqual(String tokenA, String tokenB) {
+        if (tokenA == tokenB) {
+            return true;
+        }
+
+        int lenA = tokenA.length();
+        int lenB = tokenB.length();
+
+        if (lenB == 0) {
+            return lenA == 0;
+        }
+
+        int result = 0;
+        result |= lenA - lenB;
+
+        for (int i = 0; i < lenA; i++) {
+            // If i >= lenB, indexB is 0; otherwise, i.
+            int indexB = ((i - lenB) >>> 31) * i;
+            result |= tokenA.charAt(i) ^ tokenB.charAt(indexB);
+        }
+
+        return result == 0;
     }
 
     @Override

--- a/benchmarks/src/main/java/com/palantir/tokens/auth/BearerTokenBenchmark.java
+++ b/benchmarks/src/main/java/com/palantir/tokens/auth/BearerTokenBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.tokens.auth;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Fork(1)
+@Threads(1)
+public class BearerTokenBenchmark {
+
+    private static final BearerToken TOKEN = BearerToken.valueOf("a".repeat(200));
+
+    private static final BearerToken TOKEN_FIRST_CHAR_DIFFERENT = BearerToken.valueOf("b" + "a".repeat(199));
+    private static final BearerToken TOKEN_LAST_CHAR_DIFFERENT = BearerToken.valueOf("a".repeat(199) + "b");
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public final boolean equals_firstCharDifferent() {
+        return TOKEN.equals(TOKEN_FIRST_CHAR_DIFFERENT);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public final boolean equals_lastCharDifferent() {
+        return TOKEN.equals(TOKEN_LAST_CHAR_DIFFERENT);
+    }
+
+    public static void main(String[] _args) throws Exception {
+        Options options = new OptionsBuilder()
+                .include(BearerTokenBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
This PR copies the implementation of `MessageDigest.isEqual` and adapts it to operation on `String` values using `charAt` instead if `byte[]` values. This allows us to compare `BearerToken` values without needing to allocate and retain a duplicative `byte[]` value.

## Benchmarks

#### Before

```
Benchmark                                       Mode  Cnt   Score   Error  Units
BearerTokenBenchmark.equals_firstCharDifferent  avgt    5  65.389 ± 0.853  ns/op
BearerTokenBenchmark.equals_lastCharDifferent   avgt    5  65.404 ± 1.367  ns/op
```

#### After

```
Benchmark                                       Mode  Cnt   Score   Error  Units
BearerTokenBenchmark.equals_firstCharDifferent  avgt    5  65.001 ± 0.540  ns/op
BearerTokenBenchmark.equals_lastCharDifferent   avgt    5  65.018 ± 1.407  ns/op
```