### PR TITLE
Improve performance of token comparison

### DIFF
--- a/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
+++ b/auth-tokens/src/main/java/com/palantir/tokens/auth/BearerToken.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import java.security.MessageDigest;
 import java.util.BitSet;
 
 /** Value class representing an authentication bearer token. */
@@ -96,38 +95,32 @@ public final class BearerToken {
     }
 
     @Override
+    @SuppressWarnings("ReferenceEquality")
     public boolean equals(Object other) {
         if (!(other instanceof BearerToken bearerToken)) {
             return false;
         }
 
-        return isEqual(token, bearerToken.token);
-    }
+        String tokenA = token;
+        String tokenB = bearerToken.token;
 
-    /**
-     * Copied from {@link MessageDigest#isEqual(byte[], byte[])} and modified to compare {@link String} values using
-     * {@link String#charAt(int)}.
-     */
-    @SuppressWarnings("ReferenceEquality")
-    private static boolean isEqual(String tokenA, String tokenB) {
         if (tokenA == tokenB) {
             return true;
         }
 
+        // This may allow the token length to be determined using timing attacks, but that is not something we are
+        // concerned about. Tokens have a relatively standard format and the vast majority of our bearer tokens
+        // are one of a few lengths.
         int lenA = tokenA.length();
         int lenB = tokenB.length();
-
-        if (lenB == 0) {
-            return lenA == 0;
+        if (lenA != lenB) {
+            return false;
         }
 
+        // Use a constant-time comparison to compare the token values.
         int result = 0;
-        result |= lenA - lenB;
-
         for (int i = 0; i < lenA; i++) {
-            // If i >= lenB, indexB is 0; otherwise, i.
-            int indexB = ((i - lenB) >>> 31) * i;
-            result |= tokenA.charAt(i) ^ tokenB.charAt(indexB);
+            result |= tokenA.charAt(i) ^ tokenB.charAt(i);
         }
 
         return result == 0;


### PR DESCRIPTION
## Before this PR

`BearerToken` comparison is implemented in constant time, regardless of the length of the input value.

This imposes a slight performance penalty because we need to perform some additional work to calculate the index into the input value during the comparison.

```
Benchmark                                       Mode  Cnt   Score   Error  Units
BearerTokenBenchmark.equals_firstCharDifferent  avgt    5  65.001 ± 0.540  ns/op
BearerTokenBenchmark.equals_lastCharDifferent   avgt    5  65.018 ± 1.407  ns/op
```

## After this PR

If we are willing to sacrifice constant time comparisons when the length of the input value is different than the length of our value, then we can eliminate this performance overhead.

This feels like an acceptable tradeoff for bearer tokens. In practice, our bearer tokens are relatively large (always over 50 characters, often more like 200) and going to be one of a few different lengths. Knowing the length doesn't make it meaningful easier to forge a valid token.

```
Benchmark                                       Mode  Cnt   Score   Error  Units
BearerTokenBenchmark.equals_firstCharDifferent  avgt    5  35.727 ± 0.411  ns/op
BearerTokenBenchmark.equals_lastCharDifferent   avgt    5  35.714 ± 0.358  ns/op
```